### PR TITLE
Ncon tests

### DIFF
--- a/tensornetwork/ncon_interface.py
+++ b/tensornetwork/ncon_interface.py
@@ -176,12 +176,6 @@ def _build_network(tensors, network):
     nodes = []
     edges = {}
     for (i, (tensor, edge_lbls)) in enumerate(zip(tensors, network)):
-        # Allow single indices to be passed as scalars.
-        try:
-            edge_lbls = list(edge_lbls)
-        except TypeError:
-            edge_lbls = [edge_lbls]
-
         if len(tensor.shape) != len(edge_lbls):
             raise ValueError(
                 "Incorrect number of edge labels specified tensor {}".format(i)

--- a/tensornetwork/ncon_interface.py
+++ b/tensornetwork/ncon_interface.py
@@ -176,6 +176,12 @@ def _build_network(tensors, network):
     nodes = []
     edges = {}
     for (i, (tensor, edge_lbls)) in enumerate(zip(tensors, network)):
+        # Allow single indices to be passed as scalars.
+        try:
+            edge_lbls = list(edge_lbls)
+        except TypeError:
+            edge_lbls = [edge_lbls]
+
         if len(tensor.shape) != len(edge_lbls):
             raise ValueError(
                 "Incorrect number of edge labels specified tensor {}".format(i)

--- a/tensornetwork/ncon_interface.py
+++ b/tensornetwork/ncon_interface.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """NCON interface to TensorNetwork."""
 
 from __future__ import absolute_import
@@ -21,7 +20,7 @@ from tensornetwork.tensornetwork import TensorNetwork
 
 
 def ncon(tensors, network, con_order=None, out_order=None):
-    r"""Contracts a list of tensors according to a tensor network specification.
+  r"""Contracts a list of tensors according to a tensor network specification.
 
     The network is provided as a list of lists, one for each
     tensor, specifying labels for the edges connected to that tensor.
@@ -57,36 +56,35 @@ def ncon(tensors, network, con_order=None, out_order=None):
     Returns:
       A `Tensor` resulting from the contraction of the tensor network.
     """
-    tn, con_edges, out_edges = ncon_network(
-        tensors, network, con_order=con_order, out_order=out_order)
+  tn, con_edges, out_edges = ncon_network(
+      tensors, network, con_order=con_order, out_order=out_order)
 
-    # Contract assuming all edges connecting a given pair of nodes are adjacent
-    # in con_order. If this is not the case, the contraction is sub-optimal
-    # so we throw an exception.
-    prev_nodes = []
-    while len(con_edges) > 0:
-        e = con_edges.pop(0)  # pop so that older nodes can be deallocated
-        nodes = e.get_nodes()
+  # Contract assuming all edges connecting a given pair of nodes are adjacent
+  # in con_order. If this is not the case, the contraction is sub-optimal
+  # so we throw an exception.
+  prev_nodes = []
+  while len(con_edges) > 0:
+    e = con_edges.pop(0)  # pop so that older nodes can be deallocated
+    nodes = e.get_nodes()
 
-        nodes_set = set(nodes)
-        if nodes_set != set(prev_nodes):
-            if not nodes_set.issubset(tn.nodes_set):
-                # the node pair was already contracted
-                raise ValueError(
-                    "Edge '{}' is not adjacent to other edges connecting "
-                    "'{}' and '{}' in the contraction order.".format(
-                        e, nodes[0], nodes[1]))
-            tn.contract_between(*nodes, name="con({},{})".format(*nodes))
-            prev_nodes = nodes
+    nodes_set = set(nodes)
+    if nodes_set != set(prev_nodes):
+      if not nodes_set.issubset(tn.nodes_set):
+        # the node pair was already contracted
+        raise ValueError("Edge '{}' is not adjacent to other edges connecting "
+                         "'{}' and '{}' in the contraction order.".format(
+                             e, nodes[0], nodes[1]))
+      tn.contract_between(*nodes, name="con({},{})".format(*nodes))
+      prev_nodes = nodes
 
-    # TODO: More efficient ordering of products based on out_edges
-    res_node = tn.outer_product_final_nodes(out_edges)
+  # TODO: More efficient ordering of products based on out_edges
+  res_node = tn.outer_product_final_nodes(out_edges)
 
-    return res_node.tensor
+  return res_node.tensor
 
 
 def ncon_network(tensors, network, con_order=None, out_order=None):
-    r"""Creates a TensorNetwork from a list of tensors according to `network`.
+  r"""Creates a TensorNetwork from a list of tensors according to `network`.
 
     The network is provided as a list of lists, one for each
     tensor, specifying labels for the edges connected to that tensor.
@@ -111,89 +109,78 @@ def ncon_network(tensors, network, con_order=None, out_order=None):
       con_edges: List of internal `Edge` objects in contraction order.
       out_edges: List of dangling `Edge` objects in output order.
     """
-    if len(tensors) != len(network):
-        raise ValueError('len(tensors) != len(network)')
+  if len(tensors) != len(network):
+    raise ValueError('len(tensors) != len(network)')
 
-    tn, edges = _build_network(tensors, network)
+  tn, edges = _build_network(tensors, network)
 
-    if con_order is None:
-        try:
-            con_order = sorted((k for k in edges.keys() if k >= 0))
-        except TypeError:
-            raise ValueError(
-                "Non-integer edge label(s): {}".format(list(edges.keys())))
-    else:
-        if len(con_order) != len(set(con_order)):
-            raise ValueError(
-                "Duplicate labels in con_order: {}".format(con_order)
-            )
-
-    if out_order is None:
-        try:
-            out_order = sorted((k for k in edges.keys() if k < 0), reverse=True)
-        except TypeError:
-            raise ValueError(
-                "Non-integer edge label(s): {}".format(list(edges.keys())))
-    else:
-        if len(out_order) != len(set(out_order)):
-            raise ValueError(
-                "Duplicate labels in out_order: {}".format(out_order)
-            )
-
+  if con_order is None:
     try:
-        con_edges = [edges[k] for k in con_order]
-        out_edges = [edges[k] for k in out_order]
-    except KeyError as err:
-        raise ValueError(
-            "Order contained an unknown edge label: {}".format(err.args[0]))
+      con_order = sorted((k for k in edges.keys() if k >= 0))
+    except TypeError:
+      raise ValueError("Non-integer edge label(s): {}".format(
+          list(edges.keys())))
+  else:
+    if len(con_order) != len(set(con_order)):
+      raise ValueError("Duplicate labels in con_order: {}".format(con_order))
 
-    if len(con_edges) + len(out_edges) != len(edges):
-        raise ValueError(
-            "Edges {} were not included in the contraction and output "
-            "ordering.".format(
-                list(set(edges.keys()) - set(con_order) - set(out_order)))
-            )
+  if out_order is None:
+    try:
+      out_order = sorted((k for k in edges.keys() if k < 0), reverse=True)
+    except TypeError:
+      raise ValueError("Non-integer edge label(s): {}".format(
+          list(edges.keys())))
+  else:
+    if len(out_order) != len(set(out_order)):
+      raise ValueError("Duplicate labels in out_order: {}".format(out_order))
 
-    for e in con_edges:
-        if e.is_dangling():
-            raise ValueError(
-                "Contraction edge {} appears only once in the network.".format(
-                    str(e)
-                ))
+  try:
+    con_edges = [edges[k] for k in con_order]
+    out_edges = [edges[k] for k in out_order]
+  except KeyError as err:
+    raise ValueError("Order contained an unknown edge label: {}".format(
+        err.args[0]))
 
-    for e in out_edges:
-        if not e.is_dangling():
-            raise ValueError(
-                "Output edge {} appears more than once in the network.".format(
-                    str(e)
-                ))
+  if len(con_edges) + len(out_edges) != len(edges):
+    raise ValueError(
+        "Edges {} were not included in the contraction and output "
+        "ordering.".format(
+            list(set(edges.keys()) - set(con_order) - set(out_order))))
 
-    return tn, con_edges, out_edges
+  for e in con_edges:
+    if e.is_dangling():
+      raise ValueError(
+          "Contraction edge {} appears only once in the network.".format(
+              str(e)))
+
+  for e in out_edges:
+    if not e.is_dangling():
+      raise ValueError(
+          "Output edge {} appears more than once in the network.".format(
+              str(e)))
+
+  return tn, con_edges, out_edges
 
 
 def _build_network(tensors, network):
-    tn = TensorNetwork()
-    nodes = []
-    edges = {}
-    for (i, (tensor, edge_lbls)) in enumerate(zip(tensors, network)):
-        if len(tensor.shape) != len(edge_lbls):
-            raise ValueError(
-                "Incorrect number of edge labels specified tensor {}".format(i)
-            )
+  tn = TensorNetwork()
+  nodes = []
+  edges = {}
+  for (i, (tensor, edge_lbls)) in enumerate(zip(tensors, network)):
+    if len(tensor.shape) != len(edge_lbls):
+      raise ValueError(
+          "Incorrect number of edge labels specified tensor {}".format(i))
 
-        node = tn.add_node(tensor, name="tensor_{}".format(i))
-        nodes.append(node)
+    node = tn.add_node(tensor, name="tensor_{}".format(i))
+    nodes.append(node)
 
-        for (axis_num, edge_lbl) in enumerate(edge_lbls):
-            if edge_lbl not in edges:
-                e = node[axis_num]
-                e.set_name(str(edge_lbl))
-                edges[edge_lbl] = e
-            else:
-                # This will raise an error if the edges are not dangling.
-                e = tn.connect(
-                    edges[edge_lbl],
-                    node[axis_num],
-                    name=str(edge_lbl))
-                edges[edge_lbl] = e
-    return tn, edges
+    for (axis_num, edge_lbl) in enumerate(edge_lbls):
+      if edge_lbl not in edges:
+        e = node[axis_num]
+        e.set_name(str(edge_lbl))
+        edges[edge_lbl] = e
+      else:
+        # This will raise an error if the edges are not dangling.
+        e = tn.connect(edges[edge_lbl], node[axis_num], name=str(edge_lbl))
+        edges[edge_lbl] = e
+  return tn, edges

--- a/tensornetwork/ncon_interface.py
+++ b/tensornetwork/ncon_interface.py
@@ -16,10 +16,16 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from tensornetwork.tensornetwork import TensorNetwork
+from typing import Any, Sequence, List, Optional, Union, Text, Tuple, Dict
+import numpy as np
+import tensorflow as tf
+from tensornetwork import tensornetwork
 
 
-def ncon(tensors, network, con_order=None, out_order=None):
+def ncon(tensors: Sequence[Union[np.ndarray, tf.Tensor]],
+         network: Sequence[Sequence],
+         con_order: Optional[Sequence] = None,
+         out_order: Optional[Sequence] = None) -> tf.Tensor:
   r"""Contracts a list of tensors according to a tensor network specification.
 
     The network is provided as a list of lists, one for each
@@ -83,7 +89,14 @@ def ncon(tensors, network, con_order=None, out_order=None):
   return res_node.tensor
 
 
-def ncon_network(tensors, network, con_order=None, out_order=None):
+def ncon_network(tensors: Sequence[Union[np.ndarray, tf.Tensor]],
+         network: Sequence[Sequence],
+         con_order: Optional[Sequence] = None,
+         out_order: Optional[Sequence] = None
+         ) -> Tuple[
+                tensornetwork.TensorNetwork,
+                List[tensornetwork.Edge],
+                List[tensornetwork.Edge]]:
   r"""Creates a TensorNetwork from a list of tensors according to `network`.
 
     The network is provided as a list of lists, one for each
@@ -162,8 +175,11 @@ def ncon_network(tensors, network, con_order=None, out_order=None):
   return tn, con_edges, out_edges
 
 
-def _build_network(tensors, network):
-  tn = TensorNetwork()
+def _build_network(
+    tensors: Sequence[Union[np.ndarray, tf.Tensor]],
+    network: Sequence[Sequence]
+    ) -> Tuple[tensornetwork.TensorNetwork, Dict[Any, tensornetwork.Edge]]:
+  tn = tensornetwork.TensorNetwork()
   nodes = []
   edges = {}
   for (i, (tensor, edge_lbls)) in enumerate(zip(tensors, network)):

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -72,7 +72,7 @@ class NconTest(tf.test.TestCase):
     with self.assertRaises(ValueError):
       ncon_interface.ncon([a,a], [(0,1),(1,'t')])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [0,(0,1)])
+      ncon_interface.ncon([a,a], [(0,),(0,1)])
 
   def test_invalid_order(self):
     a = tf.ones((2, 2))
@@ -112,9 +112,9 @@ class NconTest(tf.test.TestCase):
   def test_outer_product(self):
     a = np.array([1,2,3])
     b = np.array([1,2])
-    res = ncon_interface.ncon([a,b], [-1, -2])
+    res = ncon_interface.ncon([a,b], [(-1,), (-2,)])
     self.assertAllClose(res, np.kron(a,b).reshape((3,2)))
-    res = ncon_interface.ncon([a,a,a,a], [0, 0, 1, 1])
+    res = ncon_interface.ncon([a,a,a,a], [(0,), (0,), (1,), (1,)])
     self.assertEqual(res.numpy(), 196)
 
   def test_trace(self):

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import numpy as np
 import tensorflow as tf
 tf.enable_v2_behavior()
 from tensornetwork import ncon_interface
@@ -22,10 +23,117 @@ from tensornetwork import ncon_interface
 
 class NconTest(tf.test.TestCase):
 
-  def test_ncon_sanity_check(self):
+  def test_sanity_check(self):
     result = ncon_interface.ncon(
         [tf.ones((2, 2)), tf.ones((2, 2))], [(-1, 0), (0, -2)])
     self.assertAllClose(result, tf.ones((2, 2)) * 2)
+
+  def test_order_spec(self):
+    a = tf.ones((2, 2))
+
+    result = ncon_interface.ncon(
+        [a, a],
+        [(-1, 0), (0, -2)],
+        out_order=[-1,-2])
+    self.assertAllClose(result, tf.ones((2, 2)) * 2)
+
+    result = ncon_interface.ncon(
+        [a, a],
+        [(-1, 0), (0, -2)],
+        con_order=[0])
+    self.assertAllClose(result, tf.ones((2, 2)) * 2)
+
+    result = ncon_interface.ncon(
+        [a, a],
+        [(-1, 0), (0, -2)],
+        con_order=[0],
+        out_order=[-1,-2])
+    self.assertAllClose(result, tf.ones((2, 2)) * 2)
+
+  def test_order_spec_noninteger(self):
+    a = tf.ones((2, 2))
+    result = ncon_interface.ncon(
+        [a, a],
+        [('o1', 'i'), ('i', 'o2')],
+        con_order=['i'],
+        out_order=['o1','o2'])
+    self.assertAllClose(result, tf.ones((2, 2)) * 2)
+
+  def test_invalid_network(self):
+    a = tf.ones((2, 2))
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a], [(0,1),(1,0),(0,1)])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a], [(0,1),(1,1)])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a], [(0,1),(2,0)])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a], [(0,1),(1,0.1)])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a], [(0,1),(1,'t')])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a], [0,(0,1)])
+
+  def test_invalid_order(self):
+    a = tf.ones((2, 2))
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a], [(0,1),(1,0)], con_order=[1,2])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a], [(0,1),(1,0)], out_order=[-1])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon(
+        [a,a],
+        [('i1','i2'), ('i1','i2')],
+        con_order=['i1'],
+        out_order=[])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon(
+        [a,a],
+        [('i1','i2'), ('i1','i2')],
+        con_order=['i1', 'i2'],
+        out_order=['i1'])
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon(
+        [a,a],
+        [('i1','i2'), ('i1','i2')],
+        con_order=['i1', 'i1', 'i2'],
+        out_order=[])
+
+  def test_out_of_order_contraction(self):
+    a = tf.ones((2, 2, 2))
+    with self.assertRaises(ValueError):
+      ncon_interface.ncon([a,a,a], [(-1,0,2), (0,2,1),(1,-2,-3)])
+
+  def test_output_order(self):
+    a = np.random.randn(2,2)
+    res = ncon_interface.ncon([a], [(-2,-1)])
+    self.assertAllClose(res, a.transpose())
+
+  def test_outer_product(self):
+    a = np.array([1,2,3])
+    b = np.array([1,2])
+    res = ncon_interface.ncon([a,b], [-1, -2])
+    self.assertAllClose(res, np.kron(a,b).reshape((3,2)))
+    res = ncon_interface.ncon([a,a,a,a], [0, 0, 1, 1])
+    self.assertEqual(res.numpy(), 196)
+
+  def test_trace(self):
+    a = tf.ones((2, 2))
+    res = ncon_interface.ncon([a], [(0,0)])
+    self.assertEqual(res.numpy(), 2)
+
+  def test_small_matmul(self):
+    a = np.random.randn(2,2)
+    b = np.random.randn(2,2)
+    res = ncon_interface.ncon([a, b], [(0,-1), (0,-2)])
+    self.assertAllClose(res, a.transpose() @ b)
+
+  def test_contraction(self):
+    a = np.random.randn(2, 2, 2)
+    res = ncon_interface.ncon([a,a,a], [(-1,0,1), (0,1,2), (2,-2,-3)])
+    res_np = a.reshape((2,4)) @ a.reshape((4,2)) @ a.reshape((2,4))
+    res_np = res_np.reshape((2,2,2))
+    self.assertAllClose(res, res_np)
 
 
 if __name__ == '__main__':

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -24,115 +24,99 @@ from tensornetwork import ncon_interface
 class NconTest(tf.test.TestCase):
 
   def test_sanity_check(self):
-    result = ncon_interface.ncon(
-        [tf.ones((2, 2)), tf.ones((2, 2))], [(-1, 0), (0, -2)])
+    result = ncon_interface.ncon([tf.ones(
+        (2, 2)), tf.ones((2, 2))], [(-1, 0), (0, -2)])
     self.assertAllClose(result, tf.ones((2, 2)) * 2)
 
   def test_order_spec(self):
     a = tf.ones((2, 2))
 
-    result = ncon_interface.ncon(
-        [a, a],
-        [(-1, 0), (0, -2)],
-        out_order=[-1,-2])
+    result = ncon_interface.ncon([a, a], [(-1, 0), (0, -2)], out_order=[-1, -2])
     self.assertAllClose(result, tf.ones((2, 2)) * 2)
 
-    result = ncon_interface.ncon(
-        [a, a],
-        [(-1, 0), (0, -2)],
-        con_order=[0])
+    result = ncon_interface.ncon([a, a], [(-1, 0), (0, -2)], con_order=[0])
     self.assertAllClose(result, tf.ones((2, 2)) * 2)
 
-    result = ncon_interface.ncon(
-        [a, a],
-        [(-1, 0), (0, -2)],
-        con_order=[0],
-        out_order=[-1,-2])
+    result = ncon_interface.ncon([a, a], [(-1, 0), (0, -2)],
+                                 con_order=[0],
+                                 out_order=[-1, -2])
     self.assertAllClose(result, tf.ones((2, 2)) * 2)
 
   def test_order_spec_noninteger(self):
     a = tf.ones((2, 2))
-    result = ncon_interface.ncon(
-        [a, a],
-        [('o1', 'i'), ('i', 'o2')],
-        con_order=['i'],
-        out_order=['o1','o2'])
+    result = ncon_interface.ncon([a, a], [('o1', 'i'), ('i', 'o2')],
+                                 con_order=['i'],
+                                 out_order=['o1', 'o2'])
     self.assertAllClose(result, tf.ones((2, 2)) * 2)
 
   def test_invalid_network(self):
     a = tf.ones((2, 2))
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [(0,1),(1,0),(0,1)])
+      ncon_interface.ncon([a, a], [(0, 1), (1, 0), (0, 1)])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [(0,1),(1,1)])
+      ncon_interface.ncon([a, a], [(0, 1), (1, 1)])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [(0,1),(2,0)])
+      ncon_interface.ncon([a, a], [(0, 1), (2, 0)])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [(0,1),(1,0.1)])
+      ncon_interface.ncon([a, a], [(0, 1), (1, 0.1)])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [(0,1),(1,'t')])
+      ncon_interface.ncon([a, a], [(0, 1), (1, 't')])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [(0,),(0,1)])
+      ncon_interface.ncon([a, a], [(0,), (0, 1)])
 
   def test_invalid_order(self):
     a = tf.ones((2, 2))
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [(0,1),(1,0)], con_order=[1,2])
+      ncon_interface.ncon([a, a], [(0, 1), (1, 0)], con_order=[1, 2])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a], [(0,1),(1,0)], out_order=[-1])
+      ncon_interface.ncon([a, a], [(0, 1), (1, 0)], out_order=[-1])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon(
-        [a,a],
-        [('i1','i2'), ('i1','i2')],
-        con_order=['i1'],
-        out_order=[])
+      ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
+                          con_order=['i1'],
+                          out_order=[])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon(
-        [a,a],
-        [('i1','i2'), ('i1','i2')],
-        con_order=['i1', 'i2'],
-        out_order=['i1'])
+      ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
+                          con_order=['i1', 'i2'],
+                          out_order=['i1'])
     with self.assertRaises(ValueError):
-      ncon_interface.ncon(
-        [a,a],
-        [('i1','i2'), ('i1','i2')],
-        con_order=['i1', 'i1', 'i2'],
-        out_order=[])
+      ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
+                          con_order=['i1', 'i1', 'i2'],
+                          out_order=[])
 
   def test_out_of_order_contraction(self):
     a = tf.ones((2, 2, 2))
     with self.assertRaises(ValueError):
-      ncon_interface.ncon([a,a,a], [(-1,0,2), (0,2,1),(1,-2,-3)])
+      ncon_interface.ncon([a, a, a], [(-1, 0, 2), (0, 2, 1), (1, -2, -3)])
 
   def test_output_order(self):
-    a = np.random.randn(2,2)
-    res = ncon_interface.ncon([a], [(-2,-1)])
+    a = np.random.randn(2, 2)
+    res = ncon_interface.ncon([a], [(-2, -1)])
     self.assertAllClose(res, a.transpose())
 
   def test_outer_product(self):
-    a = np.array([1,2,3])
-    b = np.array([1,2])
-    res = ncon_interface.ncon([a,b], [(-1,), (-2,)])
-    self.assertAllClose(res, np.kron(a,b).reshape((3,2)))
-    res = ncon_interface.ncon([a,a,a,a], [(0,), (0,), (1,), (1,)])
+    a = np.array([1, 2, 3])
+    b = np.array([1, 2])
+    res = ncon_interface.ncon([a, b], [(-1,), (-2,)])
+    self.assertAllClose(res, np.kron(a, b).reshape((3, 2)))
+    res = ncon_interface.ncon([a, a, a, a], [(0,), (0,), (1,), (1,)])
     self.assertEqual(res.numpy(), 196)
 
   def test_trace(self):
     a = tf.ones((2, 2))
-    res = ncon_interface.ncon([a], [(0,0)])
+    res = ncon_interface.ncon([a], [(0, 0)])
     self.assertEqual(res.numpy(), 2)
 
   def test_small_matmul(self):
-    a = np.random.randn(2,2)
-    b = np.random.randn(2,2)
-    res = ncon_interface.ncon([a, b], [(0,-1), (0,-2)])
+    a = np.random.randn(2, 2)
+    b = np.random.randn(2, 2)
+    res = ncon_interface.ncon([a, b], [(0, -1), (0, -2)])
     self.assertAllClose(res, a.transpose() @ b)
 
   def test_contraction(self):
     a = np.random.randn(2, 2, 2)
-    res = ncon_interface.ncon([a,a,a], [(-1,0,1), (0,1,2), (2,-2,-3)])
-    res_np = a.reshape((2,4)) @ a.reshape((4,2)) @ a.reshape((2,4))
-    res_np = res_np.reshape((2,2,2))
+    res = ncon_interface.ncon([a, a, a], [(-1, 0, 1), (0, 1, 2), (2, -2, -3)])
+    res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
+    res_np = res_np.reshape((2, 2, 2))
     self.assertAllClose(res, res_np)
 
 


### PR DESCRIPTION
Improve `ncon()` error handling and add some tests.

Not yet tested: `ncon_network()`. Although it is implicitly tested via `ncon()`, the interface should probably be subject to tests.