### PR TITLE
Wavefunction and tree improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip3 install tensornetwork
 
 Note: The following examples assume a TensorFlow v2 interface 
 (in TF 1.13 or higher, run `tf.enable_v2_behavior()` after 
-importing tensorflow) but should also work with eager mode 
+importing TensorFlow) but should also work with eager mode 
 (`tf.enable_eager_execution()`). The actual library does work 
 under graph mode, but documentation is limited.
 
@@ -49,7 +49,7 @@ print(final_node.get_tensor().numpy()) # Should print 10.0
 ```
 
 ## Optimized Contractions.
-Usually, it is more computationally effective to flatten parallel edges before contracting them inorder to avoid trace edges.
+Usually, it is more computationally effective to flatten parallel edges before contracting them in order to avoid trace edges.
 ```python
 net = tensornetwork.TensorNetwork()
 a = net.add_node(tf.ones((2, 2, 2)))
@@ -62,7 +62,7 @@ e3 = net.connect(a[2], b[2])
 flattened_edge = net.flatten_edges([e1, e2, e3])
 print(net.contract(flattned_edge).get_tensor().numpy())
 ```
-We also have `contract_between` and `contract_parallel` for your convience. 
+We also have `contract_between` and `contract_parallel` for your convenience. 
 
 ```python
 # Contract all of the edges between a and b.
@@ -153,6 +153,6 @@ python -m examples.wavefunctions.evolution_example
 from the root directory.
 
 ## Disclaimer
-This library is in *alpha* and will be going through a lot of breaking changes. While releases will be stable enough for research, we do not recommend using this in any production enviornment yet.
+This library is in *alpha* and will be going through a lot of breaking changes. While releases will be stable enough for research, we do not recommend using this in any production environment yet.
 
 TensorNetwork is not an official Google product. Copyright 2019 The TensorNetwork Developers.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ n.reorder_edges(e_out) # Permute final tensor as necessary
 print(tf.norm(tf.matmul(a,b) - n.get_tensor()))
 ```
 
+## Advanced examples
+Some more sophisticated examples can be found under `examples/`.
+### Trotter evolution of a wavefunction
+Demonstrates time-evolution of a wavefunction, achieved by applying a quantum circuit
+derived from a Trotter decomposition of the propagator. To run from source, use
+```
+python -m examples.wavefunctions.evolution_example
+```
+from the root directory.
+
 ## Disclaimer
 This library is in *alpha* and will be going through a lot of breaking changes. While releases will be stable enough for research, we do not recommend using this in any production enviornment yet.
 

--- a/examples/wavefunctions/evolution_example.py
+++ b/examples/wavefunctions/evolution_example.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import tensorflow as tf
 tf.enable_v2_behavior()
 
-import wavefunctions
+from examples.wavefunctions import wavefunctions
 
 
 def ising_hamiltonian(N, dtype):

--- a/examples/wavefunctions/wavefunctions.py
+++ b/examples/wavefunctions/wavefunctions.py
@@ -22,7 +22,7 @@ import sys
 import tensorflow as tf
 
 import tensornetwork
-from trotter import trotter_prepare_gates
+from examples.wavefunctions.trotter import trotter_prepare_gates
 
 
 def inner(psi1, psi2):

--- a/experiments/tree_tensor_network/groundstate_example.py
+++ b/experiments/tree_tensor_network/groundstate_example.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import tensorflow as tf
 tf.enable_v2_behavior()
 
-import ttn_1d_uniform as ttn
+from experiments.tree_tensor_network import ttn_1d_uniform
 
 
 if __name__ == "__main__":
@@ -39,10 +39,10 @@ if __name__ == "__main__":
     print("System size:", 2**num_layers)
     print("Bond dimensions:", Ds)
 
-    H = ttn.get_ham_ising(dtype)
-    isos_012 = ttn.random_tree_tn_uniform(Ds, dtype, top_rank=1)
+    H = ttn_1d_uniform.get_ham_ising(dtype)
+    isos_012 = ttn_1d_uniform.random_tree_tn_uniform(Ds, dtype, top_rank=1)
 
-    isos_012 = ttn.opt_tree_energy(
+    isos_012 = ttn_1d_uniform.opt_tree_energy(
         isos_012,
         H,
         num_sweeps,


### PR DESCRIPTION
Makes wavefunction evolution and the tree example scripts runnable via e.g. `python -m examples.wavefunctions.evolution_example` from the source directory.

Also explains how to run the wavefunction example in the README.