### PR TITLE
Kill transposes 2

### DIFF
--- a/tensornetwork/backends/tensorflow/tensordot2.py
+++ b/tensornetwork/backends/tensorflow/tensordot2.py
@@ -82,7 +82,7 @@ def tensordot(a, b, axes, name=None):
     Although the graph optimizer should kill trivial transposes, it is best not
     to add them in the first place!
     """
-    # If perm is tensor-valued, this test will fail and we fall back to tranposing.
+    # If perm is tensor-valued, test will fail and we fall back to tranposing.
     if perm == list(range(len(perm))):
       return tensor
     return tf.transpose(tensor, perm)
@@ -94,8 +94,7 @@ def tensordot(a, b, axes, name=None):
     if (len(new_shape) == len(cur_shape) and
         all(d0 == d1 for d0, d1 in zip(cur_shape, new_shape))):
       return tensor
-    else:
-      return tf.reshape(tensor, new_shape)
+    return tf.reshape(tensor, new_shape)
 
   def _tensordot_reshape(a, axes, is_right_term=False):
     """Helper method to perform transpose and reshape for contraction op.
@@ -163,7 +162,8 @@ def tensordot(a, b, axes, name=None):
       #   unneeded tranposes in this case at the expense of a somewhat more
       #   complicated graph. Unclear whether this would be beneficial overall.
       flipped = is_right_term
-      perm = tf.concat([axes, free], 0) if flipped else tf.concat([free, axes], 0)
+      perm = (
+        tf.concat([axes, free], 0) if flipped else tf.concat([free, axes], 0))
       transposed_a = tf.transpose(a, perm)
 
     free_dims = tf.gather(shape_a, free)

--- a/tensornetwork/ncon_interface.py
+++ b/tensornetwork/ncon_interface.py
@@ -82,7 +82,7 @@ def ncon(tensors: Sequence[Tensor],
         raise ValueError("Edge '{}' is not adjacent to other edges connecting "
                          "'{}' and '{}' in the contraction order.".format(
                              e, nodes[0], nodes[1]))
-      if len(con_edges) == 0 and len(tn.nodes_set) == 2:
+      if not con_edges and len(tn.nodes_set) == 2:
         # If this already produces the final output, order the edges 
         # here to avoid transposes in some cases.
         tn.contract_between(

--- a/tensornetwork/ncon_interface.py
+++ b/tensornetwork/ncon_interface.py
@@ -82,7 +82,15 @@ def ncon(tensors: Sequence[Tensor],
         raise ValueError("Edge '{}' is not adjacent to other edges connecting "
                          "'{}' and '{}' in the contraction order.".format(
                              e, nodes[0], nodes[1]))
-      tn.contract_between(*nodes, name="con({},{})".format(*nodes))
+      if len(con_edges) == 0 and len(tn.nodes_set) == 2:
+        # If this already produces the final output, order the edges 
+        # here to avoid transposes in some cases.
+        tn.contract_between(
+            *nodes,
+            name="con({},{})".format(*nodes),
+            output_edge_order=out_edges)
+      else:
+        tn.contract_between(*nodes, name="con({},{})".format(*nodes))
       prev_nodes = nodes
 
   # TODO: More efficient ordering of products based on out_edges

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -681,9 +681,9 @@ def test_contract_between(backend):
 
 def test_contract_between_output_order(backend):
   net = tensornetwork.TensorNetwork(backend=backend)
-  a_val = np.random.normal(size=(2, 3, 4, 5))
-  b_val = np.random.normal(size=(3, 5, 4, 2))
-  c_val = np.random.normal(size=(2, 2))
+  a_val = np.ones((2, 3, 4, 5))
+  b_val = np.ones((3, 5, 4, 2))
+  c_val = np.ones((2, 2))
   a = net.add_node(a_val)
   b = net.add_node(b_val)
   c = net.add_node(c_val)


### PR DESCRIPTION
This adds a couple more tweaks to tensordot2 and also, perhaps more controversially, adds an `output_edge_ordering` argument to `contract_between()`. 

The latter allows `contract_between()` to flip the argument ordering in the call to `tensordot()` in case this would minimize transposition of the output tensor. For this to be possible, it must know the desired output ordering. This is used in `ncon()`.

Probably I should add some explicit tests for this is `tensornetwork_test`. Am happy to do that.