### PR TITLE
Implement copy node contraction

### DIFF
--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -279,7 +279,7 @@ class CopyNode(Node):
     assert edge.node2 is self
     return edge.node1, edge.axis1
 
-  def _get_partners(self) -> Dict[Node, Set[int]]:
+  def get_partners(self) -> Dict[Node, Set[int]]:
     partners = {}  # type: Dict[Node, Set[int]]
     for edge in self.edges:
       if edge.is_dangling():
@@ -325,7 +325,7 @@ class CopyNode(Node):
 
   def compute_contracted_tensor(self) -> Tensor:
     """Compute tensor corresponding to contraction of self with neighbors."""
-    partners = self._get_partners()
+    partners = self.get_partners()
     einsum_expression = self._make_einsum_expression(partners)
     tensors = [partner.get_tensor() for partner in partners]
     return self.backend.einsum(einsum_expression, *tensors)

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -959,7 +959,6 @@ def test_contract_copy_node(backend):
 def test_contract_copy_node_connected_neighbors(backend):
   net = tensornetwork.TensorNetwork(backend=backend)
   a = net.add_node(np.array([[1, 2, 3], [10, 20, 30]], dtype=np.float64))
-  assert a.tensor.shape == (2, 3), a.tensor.shape
   b = net.add_node(np.array([[2, 1, 1], [2, 2, 2]], dtype=np.float64))
   c = net.add_node(np.array([3, 4, 4], dtype=np.float64))
   cn = net.add_copy_node(rank=3, dimension=3)


### PR DESCRIPTION
There are two parts to contracting a copy node (i.e. a node representing a copy tensor). First, you need to compute the tensor resulting from simultaneously contracting all edges of a copy node. Second, you need to re-arrange the network to incorporate the new node and remove the old nodes. The former was done in #64. The latter is done in this PR.

Follow-up: This will help implement a new contractor based on Bucket Elimination (aka Variable Elimination). In that contractor we exploit the fact that variables (indices) to be eliminated in general correspond to copy nodes, not just single-edges.