### PR TITLE
Added remove_node method

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+master_doc = 'index'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import collections
-from typing import Any, Sequence, List, Set, Optional, Union, Text, Tuple, Type
+from typing import Any, Sequence, List, Set, Optional, Union, Text, Tuple, Type, Dict
 import numpy as np
 import weakref
 from tensornetwork import config
@@ -912,6 +912,31 @@ class TensorNetwork:
     self.connect(singular_values_node[1], right_node[0])
     self.nodes_set.remove(node)
     return left_node, singular_values_node, right_node, trun_vals
+
+  def remove_node(self, node: network_components.Node
+    ) -> Dict[Union[int, Text], network_components.Edge]:
+    """Remove a node from the network.
+
+    Args:
+      node: The node to be removed.
+
+    Returns:
+      A dictonary mapping name/index to the new broken edge.
+
+    Raises:
+      ValueError: If the node isn't in the network.
+    """
+    if node not in self:
+      raise ValueError("Node '{}' is not in the network.".format(node))
+    broken_edges = {}
+    for i, name in enumerate(node.axis_names):
+      if not node[i].is_dangling() and not node[i].is_trace():
+        edge1, edge2 = self.disconnect(node[i])
+        new_broken_edge = edge1 if edge1.node1 is not node else edge2
+        broken_edges[i] = new_broken_edge
+        broken_edges[name] = new_broken_edge
+    return broken_edges
+
 
   def check_correct(self, check_connected: bool = True) -> None:
     """Check that the network is structured correctly.

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -915,7 +915,9 @@ class TensorNetwork:
     return left_node, singular_values_node, right_node, trun_vals
 
   def remove_node(self, node: network_components.Node
-    ) -> Dict[Union[int, Text], network_components.Edge]:
+    ) -> Tuple[
+      Dict[Text, network_components.Edge],
+      Dict[int, network_components.Edge]]:
     """Remove a node from the network.
 
     Args:

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import collections
+# pylint: disable=line-too-long
 from typing import Any, Sequence, List, Set, Optional, Union, Text, Tuple, Type, Dict
 import numpy as np
 import weakref

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -935,6 +935,7 @@ class TensorNetwork:
         new_broken_edge = edge1 if edge1.node1 is not node else edge2
         broken_edges[i] = new_broken_edge
         broken_edges[name] = new_broken_edge
+    self.nodes_set.remove(node)
     return broken_edges
 
 

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -922,22 +922,26 @@ class TensorNetwork:
       node: The node to be removed.
 
     Returns:
-      A dictonary mapping name/index to the new broken edge.
+      broken_edges_by_name: A Dictionary mapping `node`'s axis names 
+        the newly broken edges.
+      broken_edges_by_axis: A Dictionary mapping `node`'s integer axis 
+        values to the newly broken edges.
 
     Raises:
       ValueError: If the node isn't in the network.
     """
     if node not in self:
       raise ValueError("Node '{}' is not in the network.".format(node))
-    broken_edges = {}
+    broken_edges_by_name = {}
+    broken_edges_by_axis = {}
     for i, name in enumerate(node.axis_names):
       if not node[i].is_dangling() and not node[i].is_trace():
         edge1, edge2 = self.disconnect(node[i])
         new_broken_edge = edge1 if edge1.node1 is not node else edge2
-        broken_edges[i] = new_broken_edge
-        broken_edges[name] = new_broken_edge
+        broken_edges_by_axis[i] = new_broken_edge
+        broken_edges_by_name[name] = new_broken_edge
     self.nodes_set.remove(node)
-    return broken_edges
+    return broken_edges_by_name, broken_edges_by_axis
 
 
   def check_correct(self, check_connected: bool = True) -> None:

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -450,6 +450,9 @@ class Edge:
     """Whether this edge is a dangling edge."""
     return self._is_dangling
 
+  def is_trace(self) -> bool:
+    return self.node1 is self.node2
+
   def is_being_used(self):
     """Whether the nodes this edge points to also use this edge.
 

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -1004,3 +1004,17 @@ def test_remove_node(backend):
   assert 2 not in broken_edges
   assert broken_edges[0] is b[0]
   assert broken_edges[1] is c[0]
+
+def test_remove_node_trace_edge(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.ones((2, 2, 2)))
+  b = net.add_node(np.ones(2))
+  net.connect(a[0], b[0])
+  net.connect(a[1], a[2])
+  broken_edges = net.remove_node(a)
+  assert 0 in broken_edges
+  assert 1 not in broken_edges
+  assert 2 not in broken_edges
+  assert broken_edges[0] is b[0]
+
+  

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -984,3 +984,22 @@ def test_contract_copy_node_connected_neighbors(backend):
 def test_bad_backend():
   with pytest.raises(ValueError):
     tensornetwork.TensorNetwork("NOT_A_BACKEND")
+
+def test_remove_node(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.ones((2, 2, 2)), axis_names=["test", "names", "ignore"])
+  b = net.add_node(np.ones((2, 2)))
+  c = net.add_node(np.ones((2, 2)))
+  net.connect(a["test"], b[0])
+  net.connect(a[1], c[0])
+  broken_edges = net.remove_node(a)
+  assert "test" in broken_edges
+  assert broken_edges["test"] is b[0]
+  assert "names" in broken_edges
+  assert broken_edges["names"] is c[0]
+  assert "ignore" not in broken_edges
+  assert 0 in broken_edges
+  assert 1 in broken_edges
+  assert 2 not in broken_edges
+  assert broken_edges[0] is b[0]
+  assert broken_edges[1] is c[0]

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -992,18 +992,18 @@ def test_remove_node(backend):
   c = net.add_node(np.ones((2, 2)))
   net.connect(a["test"], b[0])
   net.connect(a[1], c[0])
-  broken_edges = net.remove_node(a)
+  broken_edges_name, broken_edges_axis = net.remove_node(a)
   assert a not in net
-  assert "test" in broken_edges
-  assert broken_edges["test"] is b[0]
-  assert "names" in broken_edges
-  assert broken_edges["names"] is c[0]
-  assert "ignore" not in broken_edges
-  assert 0 in broken_edges
-  assert 1 in broken_edges
-  assert 2 not in broken_edges
-  assert broken_edges[0] is b[0]
-  assert broken_edges[1] is c[0]
+  assert "test" in broken_edges_name
+  assert broken_edges_name["test"] is b[0]
+  assert "names" in broken_edges_name
+  assert broken_edges_name["names"] is c[0]
+  assert "ignore" not in broken_edges_name
+  assert 0 in broken_edges_axis
+  assert 1 in broken_edges_axis
+  assert 2 not in broken_edges_axis
+  assert broken_edges_axis[0] is b[0]
+  assert broken_edges_axis[1] is c[0]
 
 def test_remove_node_trace_edge(backend):
   net = tensornetwork.TensorNetwork(backend=backend)
@@ -1011,7 +1011,7 @@ def test_remove_node_trace_edge(backend):
   b = net.add_node(np.ones(2))
   net.connect(a[0], b[0])
   net.connect(a[1], a[2])
-  broken_edges = net.remove_node(a)
+  _, broken_edges = net.remove_node(a)
   assert 0 in broken_edges
   assert 1 not in broken_edges
   assert 2 not in broken_edges

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -993,6 +993,7 @@ def test_remove_node(backend):
   net.connect(a["test"], b[0])
   net.connect(a[1], c[0])
   broken_edges = net.remove_node(a)
+  assert a not in net
   assert "test" in broken_edges
   assert broken_edges["test"] is b[0]
   assert "names" in broken_edges


### PR DESCRIPTION
This was requested in https://github.com/google/TensorNetwork/issues/82 and can be used for calculating derivatives and environments for backends without auto differentiation (i.e. pure numpy).