### PR TITLE
Shell Backend

### DIFF
--- a/tensornetwork/backends/backend_factory.py
+++ b/tensornetwork/backends/backend_factory.py
@@ -19,11 +19,13 @@ from __future__ import print_function
 from tensornetwork.backends.tensorflow import tensorflow_backend
 from tensornetwork.backends.numpy import numpy_backend
 from tensornetwork.backends.jax import jax_backend
+from tensornetwork.backends.shell import shell_backend
 
 _BACKENDS = {
     "tensorflow": tensorflow_backend.TensorFlowBackend,
     "numpy": numpy_backend.NumPyBackend,
     "jax": jax_backend.JaxBackend,
+    "shell": shell_backend.ShellBackend
 }
 
 

--- a/tensornetwork/backends/shell/__init__.py
+++ b/tensornetwork/backends/shell/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -15,8 +15,11 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from typing import Optional, Sequence, Tuple, List
+
+import functools
+import operator
 from tensornetwork.backends import base_backend
+from typing import Optional, Sequence, Tuple, List
 
 # Treat tensors as tuples that carry the real tensor's shape.
 # Conversion from tensor to tuple will happen somewhere else?
@@ -56,16 +59,14 @@ class ShellBackend(base_backend.BaseBackend):
     raise NotImplementedError("SVD shape cannot be calculated without"
                               "explicit tensor values.")
 
-  def concat(self, values: Sequence[Tensor], axis: int) -> Tensor:
-    # Does not work when axis < 0
-    concat_dim = len(values) * values[0][axis]
-    return values[0][:axis] + (concat_dim,) + values[0][axis + 1:]
+  def shape_concat(self, values: Sequence[Tensor]) -> Tensor:
+    return functools.reduce(operator.concat, values)
 
   def shape(self, tensor: Tensor) -> Tensor:
     return tensor
 
-  def prod(self, values: Tensor) -> Tensor:
-    return values
+  def shape_prod(self, values: Tensor) -> Tensor:
+    return functools.reduce(operator.mul, values)
 
   def sqrt(self, tensor: Tensor) -> Tensor:
     return tensor

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -27,6 +27,7 @@ class ShellBackend(base_backend.BaseBackend):
   """See base_backend.BaseBackend for documentation."""
 
   def __init__(self):
+    super(ShellBackend, self).__init__()
     self.name = "shell"
 
   def tensordot(self, a: Tensor, b: Tensor, axes: Sequence[Sequence[int]]):
@@ -102,3 +103,5 @@ class ShellBackend(base_backend.BaseBackend):
       ind = expr.find(char)
       if ind != -1:
         return tensors[i][ind]
+    raise ValueError("Einsum output expression contains letters not given"
+                     "in input.")

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -1,0 +1,108 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from typing import Optional, Sequence, Tuple, List
+from tensornetwork.backends import base_backend
+
+# Treat tensors as tuples that carry the real tensor's shape.
+# Conversion from tensor to tuple will happen somewhere else?
+Tensor = Tuple
+
+
+class ShellBackend(base_backend.BaseBackend):
+  """See base_backend.BaseBackend for documentation."""
+
+  def __init__(self):
+    self.name = "shell"
+
+  def tensordot(self, a: Tensor, b: Tensor, axes: Sequence[Sequence[int]]):
+    # Does not work when axis < 0
+    gen_a = (x for i, x in enumerate(a) if i not in axes[0])
+    gen_b = (x for i, x in enumerate(b) if i not in axes[1])
+    return tuple(self._concat_generators(gen_a, gen_b))
+
+  def _concat_generators(self, *gen):
+    """Concatenates Python generators."""
+    for g in gen:
+      yield from g
+
+  def reshape(self, tensor: Tensor, shape: Tensor):
+    return shape
+
+  def transpose(self, tensor, perm):
+    return tuple(tensor[i] for i in perm)
+
+  def svd_decomposition(self,
+                        tensor: Tensor,
+                        split_axis: int,
+                        max_singular_values: Optional[int] = None,
+                        max_truncation_error: Optional[float] = None
+                       ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    raise NotImplementedError("SVD shape cannot be calculated without"
+                              "explicit tensor values.")
+
+  def concat(self, values: Sequence[Tensor], axis: int) -> Tensor:
+    # Does not work when axis < 0
+    concat_dim = len(values) * values[0][axis]
+    return values[0][:axis] + (concat_dim,) + values[0][axis + 1:]
+
+  def shape(self, tensor: Tensor) -> Tensor:
+    return tensor
+
+  def prod(self, values: Tensor) -> Tensor:
+    return values
+
+  def sqrt(self, tensor: Tensor) -> Tensor:
+    return tensor
+
+  def diag(self, tensor: Tensor) -> Tensor:
+    return (3 - len(tensor)) * tensor
+
+  def convert_to_tensor(self, tensor: Tensor) -> Tensor:
+    return tensor
+
+  def trace(self, tensor: Tensor) -> Tensor:
+    return tensor[:-2]
+
+  def outer_product(self, tensor1: Tensor, tensor2: Tensor) -> Tensor:
+    return tensor1 + tensor2
+
+  def einsum(self, expression: str, *tensors: Tensor) -> Tensor:
+    expr_list = expression.split(",")
+    expr_list[-1], res = expr_list[-1].split("->")
+    shape = []
+    for char in res:
+      i, ind = self._find_char(expr_list, char)
+      shape.append(tensors[i][ind])
+    return tuple(shape)
+
+  def _find_char(self, expr_list: List[str], char: str):
+    """Finds character in einsum tensor expression.
+
+    Args:
+      expr_list: List with expression for input tensors in einsum.
+      char: One character string (letter) that corresponds to a specific
+        einsum component.
+
+    Returns:
+      i: Index of the tensor that has `char` components.
+      ind: Index of `char` in the i-th expression string.
+    """
+    for i, expr in enumerate(expr_list):
+      ind = expr.find(char)
+      if ind != -1:
+        return i, ind

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -93,7 +93,7 @@ class ShellBackend(base_backend.BaseBackend):
     new_shape = shape[:axis] + (concat_size,) + shape[axis + 1:]
     return ShellTensor(new_shape)
 
-  def concat_shape(self, values) -> Tuple:
+  def concat_shape(self, values) -> Sequence:
     tuple_values = (tuple(v) for v in values)
     return functools.reduce(operator.concat, tuple_values)
 

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -100,6 +100,9 @@ class ShellBackend(base_backend.BaseBackend):
   def shape(self, tensor: Tensor) -> Tuple:
     return tensor.shape
 
+  def shape_tuple(self, tensor: Tensor) -> Tuple[Optional[int], ...]:
+    return tensor.shape
+
   def prod(self, values: Tensor) -> int:
     # This is different from the BaseBackend prod!
     # prod calculates the product of tensor elements and cannot implemented

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -84,13 +84,9 @@ class ShellBackend(base_backend.BaseBackend):
   def einsum(self, expression: str, *tensors: Tensor) -> Tensor:
     expr_list = expression.split(",")
     expr_list[-1], res = expr_list[-1].split("->")
-    shape = []
-    for char in res:
-      i, ind = self._find_char(expr_list, char)
-      shape.append(tensors[i][ind])
-    return tuple(shape)
+    return tuple(self._find_char(expr_list, char, tensors) for char in res)
 
-  def _find_char(self, expr_list: List[str], char: str):
+  def _find_char(self, expr_list, char, tensors):
     """Finds character in einsum tensor expression.
 
     Args:
@@ -105,4 +101,4 @@ class ShellBackend(base_backend.BaseBackend):
     for i, expr in enumerate(expr_list):
       ind = expr.find(char)
       if ind != -1:
-        return i, ind
+        return tensors[i][ind]

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -46,14 +46,14 @@ class ShellBackend(base_backend.BaseBackend):
     # Does not work when axis < 0
     gen_a = (x for i, x in enumerate(a.shape) if i not in axes[0])
     gen_b = (x for i, x in enumerate(b.shape) if i not in axes[1])
-    return ShellTensor(self._concat_generators(gen_a, gen_b))
+    return ShellTensor(tuple(self._concat_generators(gen_a, gen_b)))
 
   def _concat_generators(self, *gen):
     """Concatenates Python generators."""
     for g in gen:
       yield from g
 
-  def reshape(self, tensor: Tensor, shape: Tensor) -> Tensor:
+  def reshape(self, tensor: Tensor, shape: Sequence[Any]) -> Tensor:
     tensor = tensor.reshape(shape)
     return tensor
 
@@ -81,7 +81,7 @@ class ShellBackend(base_backend.BaseBackend):
   def shape(self, tensor: Tensor) -> Tuple:
     return tensor.shape
 
-  def prod(self, values: Tensor) -> int:
+  def prod(self, values: Sequence[Any]) -> int:
     return functools.reduce(operator.mul, values)
 
   def sqrt(self, tensor: Tensor) -> Tensor:

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -59,13 +59,13 @@ class ShellBackend(base_backend.BaseBackend):
     raise NotImplementedError("SVD shape cannot be calculated without"
                               "explicit tensor values.")
 
-  def shape_concat(self, values: Sequence[Tensor]) -> Tensor:
+  def shape_concat(self, values: Sequence[Tensor]) -> Sequence:
     return functools.reduce(operator.concat, values)
 
   def shape(self, tensor: Tensor) -> Tensor:
     return tensor
 
-  def shape_prod(self, values: Tensor) -> Tensor:
+  def shape_prod(self, values: Tensor) -> int:
     return functools.reduce(operator.mul, values)
 
   def sqrt(self, tensor: Tensor) -> Tensor:

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -45,11 +45,17 @@ def test_transpose():
   shape = bkd.transpose((5, 3, 2), [0, 2, 1])
   assert shape == (5, 2, 3)
 
-def test_concat():
+def test_shape_concat():
   bkd = shell_backend.ShellBackend()
-  values = [(5, 3, 2), (5, 3, 2), (5, 3, 2)]
-  shape = bkd.concat(values, axis=2)
-  assert shape == (5, 3, 6)
+  values = [(5, 3, 2), (4, 6), (2,)]
+  shape = bkd.shape_concat(values)
+  assert shape == (5, 3, 2, 4, 6, 2)
+
+def test_shape_prod():
+  bkd = shell_backend.ShellBackend()
+  values = (5, 3, 2)
+  shape = bkd.shape_prod(values)
+  assert shape == 30
 
 def test_trace():
   bkd = shell_backend.ShellBackend()
@@ -77,7 +83,7 @@ def test_einsum():
   c = bkd.einsum(expr, a.shape, b.shape)
   assert c == np.einsum(expr, a, b).shape
 
-def test_einsum_three_tensors():
+def test_einsum_three():
   bkd = shell_backend.ShellBackend()
   a = np.ones((6, 4, 3, 10, 8))
   b = np.ones((6, 7, 4, 10, 5))

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -11,23 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Tests for tensornetwork.backends.shell.shell_backend"""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import inspect
 import numpy as np
 import pytest
 from tensornetwork import tensornetwork_test
 
+shell_tests = list(dir(tensornetwork_test))
+# Skip SVD tests because it is not implemented in shell backend
+shell_tests.remove("test_split_node")
+shell_tests.remove("test_split_node_mixed_order")
+shell_tests.remove("test_split_node_full_svd")
+shell_tests.remove("test_copy_tensor_parallel_edges")
 
 def get_shape(a):
-  if isinstance(a, int) or isinstance(a, float):
+  if isinstance(a, (int, float)):
     return tuple()
-  else:
-    return a.shape
+  return a.shape
 
-def assertShapesEqual(a, b, rtol=1e-8):
+def assertShapesEqual(a, b, rtol=1e-8, atol=1e-8):
   assert get_shape(a) == get_shape(b)
 
 @pytest.fixture(
@@ -35,22 +42,13 @@ def assertShapesEqual(a, b, rtol=1e-8):
 def backend_fixure(request):
     return request.param
 
-# Override np.testing to check only shapes and not values
+# Override np.testing to test only shapes
 np.testing.assert_allclose = assertShapesEqual
 
+# Reimplement copy tensor parallel edge test to ignore decorator
+def test_copy_tensor_parallel_edges(backend):
+  tensornetwork_test.test_copy_tensor_parallel_edges(backend)
 
-funcs = set(dir(tensornetwork_test))
-# Skip SVD tests because it is not implemented in shell backend
-funcs.remove("test_split_node")
-funcs.remove("test_split_node_mixed_order")
-funcs.remove("test_split_node_full_svd")
-# Reimplement parallel edge test to ignore decorator
-funcs.remove("test_copy_tensor_parallel_edges")
-
-
-for attr in funcs:
+for attr in shell_tests:
   if attr[:4] == "test":
     globals()[attr] = getattr(tensornetwork_test, attr)
-
-def test_copy_tensor_parallel_edges():
-  tensornetwork_test.test_copy_tensor_parallel_edges("shell")

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -15,79 +15,38 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-import numpy as np
-from tensornetwork.backends.shell import shell_backend
+from tensornetwork.tensornetwork_test import *
 
 
-def test_tensordot_matmul():
-  bkd = shell_backend.ShellBackend()
-  a = np.ones((6, 4, 3, 10))
-  b = np.ones((6, 4, 10, 5))
-  axes = [[3], [2]]
-  c = bkd.tensordot(a.shape, b.shape, axes=axes)
-  assert c == np.tensordot(a, b, axes=axes).shape
+def get_shape(a):
+  if isinstance(a, int) or isinstance(a, float):
+    return tuple()
+  else:
+    return a.shape
 
-def test_tensordot():
-  bkd = shell_backend.ShellBackend()
-  a = np.ones((6, 4, 3, 10))
-  b = np.ones((4, 6, 10, 5))
-  axes = [[0, 1, 3], [1, 0, 2]]
-  c = bkd.tensordot(a.shape, b.shape, axes=axes)
-  assert c == np.tensordot(a, b, axes=axes).shape
+def assertShapesEqual(a, b, rtol=1e-8):
+  assert get_shape(a) == get_shape(b)
 
-def test_reshape():
-  bkd = shell_backend.ShellBackend()
-  shape = bkd.reshape((5, 6), (5, 3, 2))
-  assert shape == (5, 3, 2)
+# Override np.testing to check only shapes and not values
+np.testing.assert_allclose = assertShapesEqual
 
-def test_transpose():
-  bkd = shell_backend.ShellBackend()
-  shape = bkd.transpose((5, 3, 2), [0, 2, 1])
-  assert shape == (5, 2, 3)
 
-def test_shape_concat():
-  bkd = shell_backend.ShellBackend()
-  values = [(5, 3, 2), (4, 6), (2,)]
-  shape = bkd.shape_concat(values)
-  assert shape == (5, 3, 2, 4, 6, 2)
+@pytest.fixture(
+  name="backend", params=["shell"])
+def backend_fixure(request):
+    return request.param
 
-def test_shape_prod():
-  bkd = shell_backend.ShellBackend()
-  values = (5, 3, 2)
-  shape = bkd.shape_prod(values)
-  assert shape == 30
+# Disable SVD tests since this is not implemented in shell backend
+def test_split_node(backend):
+  pass
 
-def test_trace():
-  bkd = shell_backend.ShellBackend()
-  shape = bkd.trace((5, 3, 6, 2, 2))
-  assert shape == (5, 3, 6)
+def test_split_node_mixed_order(backend):
+  pass
 
-def test_outer_product():
-  bkd = shell_backend.ShellBackend()
-  shape = bkd.outer_product((5, 2, 3), (6, 2, 4))
-  assert shape == (5, 2, 3, 6, 2, 4)
+def test_split_node_full_svd(backend):
+  pass
 
-def test_einsum_batch():
-  bkd = shell_backend.ShellBackend()
-  a = np.ones((6, 4, 3, 10))
-  b = np.ones((6, 4, 10, 5))
-  expr = "abij,abjk->abik"
-  c = bkd.einsum(expr, a.shape, b.shape)
-  assert c == np.einsum(expr, a, b).shape
-
-def test_einsum():
-  bkd = shell_backend.ShellBackend()
-  a = np.ones((6, 4, 3, 10, 8))
-  b = np.ones((6, 7, 4, 10, 5))
-  expr = "abicj,akbcl->kilj"
-  c = bkd.einsum(expr, a.shape, b.shape)
-  assert c == np.einsum(expr, a, b).shape
-
-def test_einsum_three():
-  bkd = shell_backend.ShellBackend()
-  a = np.ones((6, 4, 3, 10, 8))
-  b = np.ones((6, 7, 4, 10, 5))
-  c = np.ones((5, 3))
-  expr = "abicj,akbcl,li->jk"
-  s = bkd.einsum(expr, a.shape, b.shape, c.shape)
-  assert s == np.einsum(expr, a, b, c).shape
+# Redefine this specific test to get rid of decorator from `tensornetwork_test`
+cache_copy_tensor_parallel_edges = test_copy_tensor_parallel_edges
+def test_copy_tensor_parallel_edges(backend):
+  cache_copy_tensor_parallel_edges(backend)

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -44,8 +44,20 @@ def test_transpose():
   assertBackendsAgree("transpose", args)
 
 def test_svd_decomposition():
-  # TODO
-  pass
+  tensor = np.ones([2, 3, 4, 5, 6])
+  np_res = numpy_backend.NumPyBackend().svd_decomposition(tensor, 3)
+  sh_res = shell_backend.ShellBackend().svd_decomposition(tensor, 3)
+  for x, y in zip(np_res, sh_res):
+    assert x.shape == y.shape
+
+def test_svd_decomposition_with_max_values():
+  tensor = np.ones([2, 3, 4, 5, 6])
+  np_res = numpy_backend.NumPyBackend().svd_decomposition(
+               tensor, 3, max_singular_values=5)
+  sh_res = shell_backend.ShellBackend().svd_decomposition(
+               tensor, 3, max_singular_values=5)
+  for x, y in zip(np_res, sh_res):
+    assert x.shape == y.shape
 
 def test_concat():
   args = {"values": [np.ones([3, 2, 5]), np.zeros([3, 2, 5]),
@@ -56,8 +68,9 @@ def test_concat():
   assertBackendsAgree("concat", args)
 
 def test_concat_shape():
-  # TODO
-  pass
+  shapes = [(5, 2), (3,), (4, 6)]
+  result = shell_backend.ShellBackend().concat_shape(shapes)
+  assert result == (5, 2, 3, 4, 6)
 
 def test_shape():
   tensor = np.ones([3, 5, 2])

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -1,0 +1,87 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import numpy as np
+from tensornetwork.backends.shell import shell_backend
+
+
+def test_tensordot_matmul():
+  bkd = shell_backend.ShellBackend()
+  a = np.ones((6, 4, 3, 10))
+  b = np.ones((6, 4, 10, 5))
+  axes = [[3], [2]]
+  c = bkd.tensordot(a.shape, b.shape, axes=axes)
+  assert c == np.tensordot(a, b, axes=axes).shape
+
+def test_tensordot():
+  bkd = shell_backend.ShellBackend()
+  a = np.ones((6, 4, 3, 10))
+  b = np.ones((4, 6, 10, 5))
+  axes = [[0, 1, 3], [1, 0, 2]]
+  c = bkd.tensordot(a.shape, b.shape, axes=axes)
+  assert c == np.tensordot(a, b, axes=axes).shape
+
+def test_reshape():
+  bkd = shell_backend.ShellBackend()
+  shape = bkd.reshape((5, 6), (5, 3, 2))
+  assert shape == (5, 3, 2)
+
+def test_transpose():
+  bkd = shell_backend.ShellBackend()
+  shape = bkd.transpose((5, 3, 2), [0, 2, 1])
+  assert shape == (5, 2, 3)
+
+def test_concat():
+  bkd = shell_backend.ShellBackend()
+  values = [(5, 3, 2), (5, 3, 2), (5, 3, 2)]
+  shape = bkd.concat(values, axis=2)
+  assert shape == (5, 3, 6)
+
+def test_trace():
+  bkd = shell_backend.ShellBackend()
+  shape = bkd.trace((5, 3, 6, 2, 2))
+  assert shape == (5, 3, 6)
+
+def test_outer_product():
+  bkd = shell_backend.ShellBackend()
+  shape = bkd.outer_product((5, 2, 3), (6, 2, 4))
+  assert shape == (5, 2, 3, 6, 2, 4)
+
+def test_einsum_batch():
+  bkd = shell_backend.ShellBackend()
+  a = np.ones((6, 4, 3, 10))
+  b = np.ones((6, 4, 10, 5))
+  expr = "abij,abjk->abik"
+  c = bkd.einsum(expr, a.shape, b.shape)
+  assert c == np.einsum(expr, a, b).shape
+
+def test_einsum():
+  bkd = shell_backend.ShellBackend()
+  a = np.ones((6, 4, 3, 10, 8))
+  b = np.ones((6, 7, 4, 10, 5))
+  expr = "abicj,akbcl->kilj"
+  c = bkd.einsum(expr, a.shape, b.shape)
+  assert c == np.einsum(expr, a, b).shape
+
+def test_einsum_three_tensors():
+  bkd = shell_backend.ShellBackend()
+  a = np.ones((6, 4, 3, 10, 8))
+  b = np.ones((6, 7, 4, 10, 5))
+  c = np.ones((5, 3))
+  expr = "abicj,akbcl,li->jk"
+  s = bkd.einsum(expr, a.shape, b.shape, c.shape)
+  assert s == np.einsum(expr, a, b, c).shape

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -78,6 +78,12 @@ def test_shape():
   sh_result = shell_backend.ShellBackend().shape(tensor)
   assert np_result == sh_result
 
+def test_shape_tuple():
+  tensor = np.ones([3, 5, 2])
+  np_result = numpy_backend.NumPyBackend().shape_tuple(tensor)
+  sh_result = shell_backend.ShellBackend().shape_tuple(tensor)
+  assert np_result == sh_result
+
 def test_prod():
   result = shell_backend.ShellBackend().prod(np.ones([3, 5, 2]))
   assert result == 30


### PR DESCRIPTION
Not sure if these issues are still relevant but that's a first try for #72 .
It treats `Tensor` as a tuple that has the corresponding tensor shape but depending on how the conversion from tensor to shape will work, we may need to change that.
SVD is not implemented because I am not sure how we should treat the truncation size when we do not have the actual tensor values to find singular values and compare to cut-off.