### PR TITLE
Simplify the naive_contractor

### DIFF
--- a/tensornetwork/contractors/naive_contractor.py
+++ b/tensornetwork/contractors/naive_contractor.py
@@ -41,16 +41,11 @@ def naive(net: network.TensorNetwork,
       contracted or flattened.
   """
   if edge_order is None:
-    edge_order = net.edge_order
+    edge_order = sorted(net.get_all_nondangling())
   if set(edge_order) != net.get_all_nondangling():
-    raise ValueError("Some non-dangling edges that were orginally created by "
-                     "`connect` are no longer in the graph. Please do NOT use"
-                     " any edge manipulation methods (contract, flatten, "
-                     "split_node, etc) before using the naive contractor.\n"
-                     "Original edges missing: {}.\n"
-                     "New edges found: {}".format(
-                         set(edge_order) - net.get_all_nondangling(),
-                         net.get_all_nondangling() - set(edge_order)))
+    raise ValueError("Set of passed edges does not match expected set."
+                     "Given: {}\nExpected: {}".format(
+                          edge_order, net.get_all_nondangling()))
   for edge in edge_order:
     if edge in net:
       net.contract_parallel(edge)

--- a/tensornetwork/contractors/naive_contractor_test.py
+++ b/tensornetwork/contractors/naive_contractor_test.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import pytest
 
 from tensornetwork import network
 from tensornetwork.contractors import naive_contractor
@@ -26,53 +26,49 @@ from tensornetwork.contractors import naive_contractor
 naive = naive_contractor.naive
 
 
-class NaiveTest(tf.test.TestCase):
 
-  def test_sanity_check(self):
-    net = network.TensorNetwork(backend="tensorflow")
-    a = net.add_node(np.eye(2))
-    b = net.add_node(np.eye(2))
-    c = net.add_node(np.eye(2))
-    net.connect(a[0], b[1])
-    net.connect(b[0], c[1])
-    net.connect(c[0], a[1])
-    result = naive(net).get_final_node()
-    self.assertAllClose(result.get_tensor(), 2.0)
+def test_sanity_check(backend):
+  net = network.TensorNetwork(backend=backend)
+  a = net.add_node(np.eye(2))
+  b = net.add_node(np.eye(2))
+  c = net.add_node(np.eye(2))
+  net.connect(a[0], b[1])
+  net.connect(b[0], c[1])
+  net.connect(c[0], a[1])
+  result = naive(net).get_final_node()
+  np.testing.assert_allclose(result.tensor, 2.0)
 
-  def test_passed_edge_order(self):
-    net = network.TensorNetwork(backend="tensorflow")
-    a = net.add_node(np.eye(2))
-    b = net.add_node(np.eye(2))
-    c = net.add_node(np.eye(2))
-    e1 = net.connect(a[0], b[1])
-    e2 = net.connect(b[0], c[1])
-    e3 = net.connect(c[0], a[1])
-    result = naive(net, [e3, e1, e2]).get_final_node()
-    self.assertAllClose(result.get_tensor(), 2.0)
+def test_passed_edge_order(backend):
+  net = network.TensorNetwork(backend=backend)
+  a = net.add_node(np.eye(2))
+  b = net.add_node(np.eye(2))
+  c = net.add_node(np.eye(2))
+  e1 = net.connect(a[0], b[1])
+  e2 = net.connect(b[0], c[1])
+  e3 = net.connect(c[0], a[1])
+  result = naive(net, [e3, e1, e2]).get_final_node()
+  np.testing.assert_allclose(result.tensor, 2.0)
 
-  def test_bad_passed_edges(self):
-    net = network.TensorNetwork(backend="tensorflow")
-    a = net.add_node(np.eye(2))
-    b = net.add_node(np.eye(2))
-    c = net.add_node(np.eye(2))
-    e1 = net.connect(a[0], b[1])
-    e2 = net.connect(b[0], c[1])
-    _ = net.connect(c[0], a[1])
-    with self.assertRaises(ValueError):
-      naive(net, [e1, e2])
+def test_bad_passed_edges(backend):
+  net = network.TensorNetwork(backend=backend)
+  a = net.add_node(np.eye(2))
+  b = net.add_node(np.eye(2))
+  c = net.add_node(np.eye(2))
+  e1 = net.connect(a[0], b[1])
+  e2 = net.connect(b[0], c[1])
+  _ = net.connect(c[0], a[1])
+  with pytest.raises(ValueError):
+    naive(net, [e1, e2])
 
-  def test_precontracted_network(self):
-    net = network.TensorNetwork(backend="tensorflow")
-    a = net.add_node(np.eye(2))
-    b = net.add_node(np.eye(2))
-    c = net.add_node(np.eye(2))
-    net.connect(a[0], b[1])
-    net.connect(b[0], c[1])
-    edge = net.connect(c[0], a[1])
-    net.contract(edge)
-    with self.assertRaises(ValueError):
-      naive(net)
-
-
-if __name__ == '__main__':
-  tf.test.main()
+def test_precontracted_network(backend):
+  net = network.TensorNetwork(backend=backend)
+  a = net.add_node(np.eye(2))
+  b = net.add_node(np.eye(2))
+  c = net.add_node(np.eye(2))
+  net.connect(a[0], b[1])
+  net.connect(b[0], c[1])
+  edge = net.connect(c[0], a[1])
+  net.contract(edge)
+  # This should work now!
+  result = naive(net).get_final_node()
+  np.testing.assert_allclose(result.tensor, 2.0)

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -35,7 +35,6 @@ class TensorNetwork:
       backend = config.default_backend
     self.backend = backend_factory.get_backend(backend)
     self.nodes_set = set()
-    self.edge_order = []
     # These increments are only used for generating names.
     self.node_increment = 0
     self.edge_increment = 0
@@ -68,7 +67,6 @@ class TensorNetwork:
     # Add increment for namings.
     self.node_increment += subnetwork.node_increment
     self.edge_increment += subnetwork.edge_increment
-    self.edge_order += subnetwork.edge_order
 
   # TODO: Add pytypes once we figure out why it crashes.
   @classmethod
@@ -196,7 +194,6 @@ class TensorNetwork:
     new_edge.set_signature(self.edge_increment)
     node1.add_edge(new_edge, axis1_num)
     node2.add_edge(new_edge, axis2_num)
-    self.edge_order.append(new_edge)
     return new_edge
 
   def disconnect(self,
@@ -230,7 +227,6 @@ class TensorNetwork:
                                               edge.axis2)
     node1.add_edge(dangling_edge_1, edge.axis1, True)
     node2.add_edge(dangling_edge_2, edge.axis2, True)
-    self.edge_order.remove(edge)
     return [dangling_edge_1, dangling_edge_2]
 
   def _remove_trace_edge(self, edge: network_components.Edge,
@@ -423,7 +419,6 @@ class TensorNetwork:
     for partner in partners:
         for edge in partner.edges:
             if edge.node1 is copy_node or edge.node2 is copy_node:
-                self.edge_order.remove(edge)
                 continue
             old_axis = edge.axis1 if edge.node1 is partner else edge.axis2
             edge.update_axis(

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -643,7 +643,6 @@ def test_add_subnetwork(backend):
   e2 = net2.connect(c[0], a[1])
   e3 = net2.connect(c[1], b[1])
   net2.check_correct()
-  assertEqual(net2.edge_order, [e1, e2, e3])
   for edge in [e1, e2, e3]:
     net2.contract(edge)
   result = net2.get_final_node()
@@ -1137,3 +1136,14 @@ def test_get_parallel_edge(backend):
   # sort by edge signature
   a = sorted(list(edges))[0]
   assert net.get_parallel_edges(a) == edges
+
+def test_edge_sorting(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.eye(2))
+  b = net.add_node(np.eye(2))
+  c = net.add_node(np.eye(2))
+  e1 = net.connect(a[0], b[1])
+  e2 = net.connect(b[0], c[1])
+  e3 = net.connect(c[0], a[1])
+  sorted_edges = sorted([e2, e3, e1])
+  assert sorted_edges == [e1, e2, e3]


### PR DESCRIPTION
Since edges now have signatures that are directly related to the order in which they were created/added, we can use this as the ordering for the naive contractor. This in turn allows us to FINALLY totally remove the hacky `edge_order` list in `TensorNetwork`.