### PR TITLE
Converting AUTHORS.md to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+# This is the list of TensorNetwork authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+
+Google LLC

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,0 @@
-# This is the list of TensorNetwork authors for copyright purposes.
-
-This does not necessarily list everyone who has contributed code, since in
-some cases, their employer may be the copyright holder.  To see the full list
-of contributors, see the revision history in source control.
-
-1. Google LLC

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,7 @@
 # This is the list of TensorNetwork authors for copyright purposes.
-#
-# This does not necessarily list everyone who has contributed code, since in
-# some cases, their employer may be the copyright holder.  To see the full list
-# of contributors, see the revision history in source control.
-Google LLC
+
+This does not necessarily list everyone who has contributed code, since in
+some cases, their employer may be the copyright holder.  To see the full list
+of contributors, see the revision history in source control.
+
+1. Google LLC


### PR DESCRIPTION
All the contents of the markdown file are marked as title instead of propering structuring it in the form of title, body and list of contributors.