### PR TITLE
Trigger ncon ordering exceptions again.

### DIFF
--- a/tensornetwork/ncon_interface.py
+++ b/tensornetwork/ncon_interface.py
@@ -77,17 +77,17 @@ def ncon(tensors: Sequence[Tensor],
   # Reverse the list so we can pop from the end: O(1).
   con_edges = con_edges[::-1]
   while con_edges:
-    e = con_edges.pop()
-    nodes_to_contract = e.get_nodes()
+    nodes_to_contract = con_edges[-1].get_nodes()
     edges_to_contract = tn.get_shared_edges(*nodes_to_contract)
 
     # Eat up all parallel edges that are adjacent in the ordering.
-    adjacent_parallel_edges = {e}
-    while con_edges:
-      if con_edges[-1] in edges_to_contract:
-        adjacent_parallel_edges.add(con_edges.pop())
+    adjacent_parallel_edges = set()
+    for edge in reversed(con_edges):
+      if edge in edges_to_contract:
+        adjacent_parallel_edges.add(edge)
       else:
         break
+    con_edges = con_edges[:-len(adjacent_parallel_edges)]
 
     # In an optimal ordering, all edges connecting a given pair of nodes are
     # adjacent in con_order. If this is not the case, warn the user.

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -15,113 +15,118 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import pytest
 import numpy as np
 import tensorflow as tf
 tf.compat.v1.enable_v2_behavior()
 from tensornetwork import ncon_interface
 
 
-class NconTest(tf.test.TestCase):
-
-  def test_sanity_check(self):
-    result = ncon_interface.ncon([tf.ones(
-        (2, 2)), tf.ones((2, 2))], [(-1, 1), (1, -2)])
-    self.assertAllClose(result, tf.ones((2, 2)) * 2)
-
-  def test_order_spec(self):
-    a = tf.ones((2, 2))
-
-    result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2])
-    self.assertAllClose(result, tf.ones((2, 2)) * 2)
-
-    result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1])
-    self.assertAllClose(result, tf.ones((2, 2)) * 2)
-
-    result = ncon_interface.ncon(
-        [a, a], [(-1, 1), (1, -2)], con_order=[1], out_order=[-1, -2])
-    self.assertAllClose(result, tf.ones((2, 2)) * 2)
-
-  def test_order_spec_noninteger(self):
-    a = tf.ones((2, 2))
-    result = ncon_interface.ncon(
-        [a, a], [('o1', 'i'), ('i', 'o2')],
-        con_order=['i'],
-        out_order=['o1', 'o2'])
-    self.assertAllClose(result, tf.ones((2, 2)) * 2)
-
-  def test_invalid_network(self):
-    a = tf.ones((2, 2))
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(1, 2), (2, 2)])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(1, 2), (3, 1)])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(1, 2), (2, 't')])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(0, 1), (1, 0)])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(1,), (1, 2)])
-
-  def test_invalid_order(self):
-    a = tf.ones((2, 2))
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon(
-          [a, a], [('i1', 'i2'), ('i1', 'i2')], con_order=['i1'], out_order=[])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon(
-          [a, a], [('i1', 'i2'), ('i1', 'i2')],
-          con_order=['i1', 'i2'],
-          out_order=['i1'])
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon(
-          [a, a], [('i1', 'i2'), ('i1', 'i2')],
-          con_order=['i1', 'i1', 'i2'],
-          out_order=[])
-
-  def test_out_of_order_contraction(self):
-    a = tf.ones((2, 2, 2))
-    with self.assertRaises(ValueError):
-      ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)])
-
-  def test_output_order(self):
-    a = np.random.randn(2, 2)
-    res = ncon_interface.ncon([a], [(-2, -1)])
-    self.assertAllClose(res, a.transpose())
-
-  def test_outer_product(self):
-    a = np.array([1, 2, 3])
-    b = np.array([1, 2])
-    res = ncon_interface.ncon([a, b], [(-1,), (-2,)])
-    self.assertAllClose(res, np.kron(a, b).reshape((3, 2)))
-    res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)])
-    self.assertEqual(res.numpy(), 196)
-
-  def test_trace(self):
-    a = tf.ones((2, 2))
-    res = ncon_interface.ncon([a], [(1, 1)])
-    self.assertEqual(res.numpy(), 2)
-
-  def test_small_matmul(self):
-    a = np.random.randn(2, 2)
-    b = np.random.randn(2, 2)
-    res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)])
-    self.assertAllClose(res, a.transpose() @ b)
-
-  def test_contraction(self):
-    a = np.random.randn(2, 2, 2)
-    res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)])
-    res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
-    res_np = res_np.reshape((2, 2, 2))
-    self.assertAllClose(res, res_np)
+def test_sanity_check():
+  result = ncon_interface.ncon([tf.ones(
+      (2, 2)), tf.ones((2, 2))], [(-1, 1), (1, -2)])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
 
 
-if __name__ == '__main__':
-  tf.test.main()
+def test_order_spec():
+  a = tf.ones((2, 2))
+
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+  result = ncon_interface.ncon(
+      [a, a], [(-1, 1), (1, -2)], con_order=[1], out_order=[-1, -2])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+
+def test_order_spec_noninteger():
+  a = tf.ones((2, 2))
+  result = ncon_interface.ncon(
+      [a, a], [('o1', 'i'), ('i', 'o2')],
+      con_order=['i'],
+      out_order=['o1', 'o2'])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+
+def test_invalid_network():
+  a = tf.ones((2, 2))
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 2)])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (3, 1)])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 't')])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(0, 1), (1, 0)])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1,), (1, 2)])
+
+
+def test_invalid_order():
+  a = tf.ones((2, 2))
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon(
+        [a, a], [('i1', 'i2'), ('i1', 'i2')], con_order=['i1'], out_order=[])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon(
+        [a, a], [('i1', 'i2'), ('i1', 'i2')],
+        con_order=['i1', 'i2'],
+        out_order=['i1'])
+  with pytest.raises(ValueError):
+    ncon_interface.ncon(
+        [a, a], [('i1', 'i2'), ('i1', 'i2')],
+        con_order=['i1', 'i1', 'i2'],
+        out_order=[])
+
+
+def test_out_of_order_contraction():
+  a = tf.ones((2, 2, 2))
+  with pytest.warns(UserWarning, match='Suboptimal ordering'):
+    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)])
+
+
+def test_output_order():
+  a = np.random.randn(2, 2)
+  res = ncon_interface.ncon([a], [(-2, -1)])
+  np.testing.assert_allclose(res, a.transpose())
+
+
+def test_outer_product():
+  a = np.array([1, 2, 3])
+  b = np.array([1, 2])
+  res = ncon_interface.ncon([a, b], [(-1,), (-2,)])
+  np.testing.assert_allclose(res, np.kron(a, b).reshape((3, 2)))
+  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)])
+  assert res.numpy() == 196
+
+
+def test_trace():
+  a = tf.ones((2, 2))
+  res = ncon_interface.ncon([a], [(1, 1)])
+  assert res.numpy() == 2
+
+
+def test_small_matmul():
+  a = np.random.randn(2, 2)
+  b = np.random.randn(2, 2)
+  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)])
+  np.testing.assert_allclose(res, a.transpose() @ b)
+
+
+def test_contraction():
+  a = np.random.randn(2, 2, 2)
+  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)])
+  res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
+  res_np = res_np.reshape((2, 2, 2))
+  np.testing.assert_allclose(res, res_np)


### PR DESCRIPTION
This broke due to the weak references stuff. Fix it and simplify the ncon contraction loop in the process.
Fixes #148.