### PR TITLE
Opt einsum

### DIFF
--- a/tensornetwork/contractors/naive_contractor.py
+++ b/tensornetwork/contractors/naive_contractor.py
@@ -23,15 +23,18 @@ from tensornetwork import network_components
 
 
 def naive(net: network.TensorNetwork,
-          edge_order: Optional[Sequence[network_components.Edge]] = None
+          output_edge_order: Sequence[Sequence[network_components.Edge]],
+          edge_order: Optional[Sequence[network_components.Edge]] = None,
          ) -> network.TensorNetwork:
   """Contract a TensorNetwork in the order the edges were created.
+  if `edge_order` is passed, contract the network in the order of `edge_order`.
 
   This contraction method will usually be very suboptimal unless the edges were
   created in a deliberate way.
 
   Args:
     net: A TensorNetwork.
+    output_edge_order: A list of lists of edges. Edges of the final nodes in `nodes_set` are reordered into `output_edge_order`
     edge_order: An optional list of edges. Must be equal to all non-dangling
       edges in the net.
   Returns:
@@ -42,11 +45,27 @@ def naive(net: network.TensorNetwork,
   """
   if edge_order is None:
     edge_order = sorted(net.get_all_nondangling())
+    
   if set(edge_order) != net.get_all_nondangling():
     raise ValueError("Set of passed edges does not match expected set."
                      "Given: {}\nExpected: {}".format(
                           edge_order, net.get_all_nondangling()))
+
+  if set([edge for edge_list in output_edge_order for edge in edge_list]) != (net.get_all_edges() - net.get_all_nondangling()):
+    raise ValueError("output edges are not all dangling.")
+  
   for edge in edge_order:
     if edge in net:
       net.contract_parallel(edge)
+      
+  if len(net.nodes_set) != len(output_edge_order):
+    raise ValueError("number of elements {0} in `output_edge_order` is not matching"
+                     " the number of remaining nodes {1} in `nodes_set`".format(len(output_edge_order), len(net.nodes_set)))
+  for order in output_edge_order:
+    if not any([set(order) == set(node.edges) for node in net.nodes_set]):
+      raise ValueError('elements {0} in `output_edge_order` do not match any node-edges in `node_set`'.format([o.name for o in order]))
+    
+  node_order_pairs = [(node, order) for order in output_edge_order for node in net.nodes_set  if set(node.edges) == set(order)]    
+  net.nodes_set = set([node.reorder_edges(order) for node, order in node_order_pairs])
   return net
+

--- a/tensornetwork/contractors/naive_contractor.py
+++ b/tensornetwork/contractors/naive_contractor.py
@@ -23,18 +23,15 @@ from tensornetwork import network_components
 
 
 def naive(net: network.TensorNetwork,
-          output_edge_order: Sequence[Sequence[network_components.Edge]],
-          edge_order: Optional[Sequence[network_components.Edge]] = None,
+          edge_order: Optional[Sequence[network_components.Edge]] = None
          ) -> network.TensorNetwork:
   """Contract a TensorNetwork in the order the edges were created.
-  if `edge_order` is passed, contract the network in the order of `edge_order`.
 
   This contraction method will usually be very suboptimal unless the edges were
   created in a deliberate way.
 
   Args:
     net: A TensorNetwork.
-    output_edge_order: A list of lists of edges. Edges of the final nodes in `nodes_set` are reordered into `output_edge_order`
     edge_order: An optional list of edges. Must be equal to all non-dangling
       edges in the net.
   Returns:
@@ -45,27 +42,11 @@ def naive(net: network.TensorNetwork,
   """
   if edge_order is None:
     edge_order = sorted(net.get_all_nondangling())
-    
   if set(edge_order) != net.get_all_nondangling():
     raise ValueError("Set of passed edges does not match expected set."
                      "Given: {}\nExpected: {}".format(
                           edge_order, net.get_all_nondangling()))
-
-  if set([edge for edge_list in output_edge_order for edge in edge_list]) != (net.get_all_edges() - net.get_all_nondangling()):
-    raise ValueError("output edges are not all dangling.")
-  
   for edge in edge_order:
     if edge in net:
       net.contract_parallel(edge)
-      
-  if len(net.nodes_set) != len(output_edge_order):
-    raise ValueError("number of elements {0} in `output_edge_order` is not matching"
-                     " the number of remaining nodes {1} in `nodes_set`".format(len(output_edge_order), len(net.nodes_set)))
-  for order in output_edge_order:
-    if not any([set(order) == set(node.edges) for node in net.nodes_set]):
-      raise ValueError('elements {0} in `output_edge_order` do not match any node-edges in `node_set`'.format([o.name for o in order]))
-    
-  node_order_pairs = [(node, order) for order in output_edge_order for node in net.nodes_set  if set(node.edges) == set(order)]    
-  net.nodes_set = set([node.reorder_edges(order) for node, order in node_order_pairs])
   return net
-

--- a/tensornetwork/contractors/naive_contractor_test.py
+++ b/tensornetwork/contractors/naive_contractor_test.py
@@ -22,7 +22,8 @@ import pytest
 
 from tensornetwork import network
 from tensornetwork.contractors import naive_contractor
-
+import tensorflow as tf
+tf.enable_v2_behavior()
 naive = naive_contractor.naive
 
 

--- a/tensornetwork/contractors/naive_contractor_test.py
+++ b/tensornetwork/contractors/naive_contractor_test.py
@@ -35,7 +35,7 @@ def test_sanity_check(backend):
   net.connect(a[0], b[1])
   net.connect(b[0], c[1])
   net.connect(c[0], a[1])
-  result = naive(net,output_edge_order=[[]]).get_final_node()
+  result = naive(net).get_final_node()
   np.testing.assert_allclose(result.tensor, 2.0)
 
 def test_passed_edge_order(backend):
@@ -46,7 +46,7 @@ def test_passed_edge_order(backend):
   e1 = net.connect(a[0], b[1])
   e2 = net.connect(b[0], c[1])
   e3 = net.connect(c[0], a[1])
-  result = naive(net, output_edge_order=[[]], edge_order=[e3, e1, e2]).get_final_node()
+  result = naive(net, [e3, e1, e2]).get_final_node()
   np.testing.assert_allclose(result.tensor, 2.0)
 
 def test_bad_passed_edges(backend):
@@ -58,31 +58,8 @@ def test_bad_passed_edges(backend):
   e2 = net.connect(b[0], c[1])
   _ = net.connect(c[0], a[1])
   with pytest.raises(ValueError):
-    naive(net, output_edge_order=[[]],edge_order=[e1, e2])
+    naive(net, [e1, e2])
 
-def test_bad_output_edge_order(backend):
-  net = network.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  c = net.add_node(np.eye(2))
-  net.connect(a[0], b[1])
-  net.connect(b[0], c[1])
-  order = [[a[1], c[1]]]
-  with pytest.raises(ValueError):
-    naive(net, output_edge_order=order)
-
-def test_bad_output_edge_order_disconnected(backend):
-  net = network.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  c = net.add_node(np.eye(2))
-  d = net.add_node(np.eye(2))  
-  net.connect(a[0], b[1])
-  net.connect(b[0], c[1])
-  order = [[a[1], d[0]], [d[1], c[0]]]
-  with pytest.raises(ValueError):
-    naive(net, output_edge_order=order)
-    
 def test_precontracted_network(backend):
   net = network.TensorNetwork(backend=backend)
   a = net.add_node(np.eye(2))
@@ -93,5 +70,5 @@ def test_precontracted_network(backend):
   edge = net.connect(c[0], a[1])
   net.contract(edge)
   # This should work now!
-  result = naive(net,output_edge_order=[[]]).get_final_node()
+  result = naive(net).get_final_node()
   np.testing.assert_allclose(result.tensor, 2.0)

--- a/tensornetwork/contractors/naive_contractor_test.py
+++ b/tensornetwork/contractors/naive_contractor_test.py
@@ -35,7 +35,7 @@ def test_sanity_check(backend):
   net.connect(a[0], b[1])
   net.connect(b[0], c[1])
   net.connect(c[0], a[1])
-  result = naive(net).get_final_node()
+  result = naive(net,output_edge_order=[[]]).get_final_node()
   np.testing.assert_allclose(result.tensor, 2.0)
 
 def test_passed_edge_order(backend):
@@ -46,7 +46,7 @@ def test_passed_edge_order(backend):
   e1 = net.connect(a[0], b[1])
   e2 = net.connect(b[0], c[1])
   e3 = net.connect(c[0], a[1])
-  result = naive(net, [e3, e1, e2]).get_final_node()
+  result = naive(net, output_edge_order=[[]], edge_order=[e3, e1, e2]).get_final_node()
   np.testing.assert_allclose(result.tensor, 2.0)
 
 def test_bad_passed_edges(backend):
@@ -58,8 +58,31 @@ def test_bad_passed_edges(backend):
   e2 = net.connect(b[0], c[1])
   _ = net.connect(c[0], a[1])
   with pytest.raises(ValueError):
-    naive(net, [e1, e2])
+    naive(net, output_edge_order=[[]],edge_order=[e1, e2])
 
+def test_bad_output_edge_order(backend):
+  net = network.TensorNetwork(backend=backend)
+  a = net.add_node(np.eye(2))
+  b = net.add_node(np.eye(2))
+  c = net.add_node(np.eye(2))
+  net.connect(a[0], b[1])
+  net.connect(b[0], c[1])
+  order = [[a[1], c[1]]]
+  with pytest.raises(ValueError):
+    naive(net, output_edge_order=order)
+
+def test_bad_output_edge_order_disconnected(backend):
+  net = network.TensorNetwork(backend=backend)
+  a = net.add_node(np.eye(2))
+  b = net.add_node(np.eye(2))
+  c = net.add_node(np.eye(2))
+  d = net.add_node(np.eye(2))  
+  net.connect(a[0], b[1])
+  net.connect(b[0], c[1])
+  order = [[a[1], d[0]], [d[1], c[0]]]
+  with pytest.raises(ValueError):
+    naive(net, output_edge_order=order)
+    
 def test_precontracted_network(backend):
   net = network.TensorNetwork(backend=backend)
   a = net.add_node(np.eye(2))
@@ -70,5 +93,5 @@ def test_precontracted_network(backend):
   edge = net.connect(c[0], a[1])
   net.contract(edge)
   # This should work now!
-  result = naive(net).get_final_node()
+  result = naive(net,output_edge_order=[[]]).get_final_node()
   np.testing.assert_allclose(result.tensor, 2.0)

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -22,63 +22,66 @@ from tensornetwork.contractors.opt_einsum_paths import utils
 
 
 def base(net: network.TensorNetwork,
-         algorithm: Callable[[List[Set[int]], Set[int], Dict[int, int]],
-                             List],
+         algorithm: Callable[[List[Set[int]], Set[int], Dict[int, int]], List],
          output_edge_order: Sequence[network_components.Edge] = None
-) -> network.TensorNetwork:
-  """Base method for all `opt_einsum` contractors.
+        ) -> network.TensorNetwork:
+    """Base method for all `opt_einsum` contractors.
 
   Args:
     net: a TensorNetwork object. Should be connected.
     algorithm: `opt_einsum` contraction method to use.
-    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
-                       are reordered into `output_edge_order`; if final node has more than one edge, 
+    output_edge_order: An optional list of edges. Edges of the 
+                       final node in `nodes_set` 
+                       are reordered into `output_edge_order`; 
+                       if final node has more than one edge, 
                        `output_edge_order` must be provided.
   Returns:
     The network after full contraction.
   """
 
-  
-  net.check_connected()
-  # First contract all trace edges
-  edges = net.get_all_nondangling()
-  for edge in edges:
-    if edge in net and edge.is_trace():
-      net.contract_parallel(edge)
-  if not net.get_all_nondangling():
-    # There's nothing to contract.
+    net.check_connected()
+    # First contract all trace edges
+    edges = net.get_all_nondangling()
+    for edge in edges:
+        if edge in net and edge.is_trace():
+            net.contract_parallel(edge)
+    if not net.get_all_nondangling():
+        # There's nothing to contract.
+        return net
+
+    # Then apply `opt_einsum`'s algorithm
+    nodes = sorted(net.nodes_set)
+    input_sets = utils.get_input_sets(net)
+    output_set = utils.get_output_set(net)
+    size_dict = utils.get_size_dict(net)
+    path = algorithm(input_sets, output_set, size_dict)
+    for a, b in path:
+        new_node = nodes[a] @ nodes[b]
+        nodes.append(new_node)
+        nodes = utils.multi_remove(nodes, [a, b])
+
+    # if the final node has more than one edge, output_edge_order has to be specified
+    final_node = net.get_final_node()
+    if (len(final_node.edges) <= 1) and (output_edge_order is None):
+        output_edge_order = list(
+            (net.get_all_edges() - net.get_all_nondangling()))
+    elif (len(final_node.edges) > 1) and (output_edge_order is None):
+        raise ValueError(
+            'if the final node has more than one dangling edge, `output_edge_order` has to be provided'
+        )
+
+    if set(output_edge_order) != (
+            net.get_all_edges() - net.get_all_nondangling()):
+        raise ValueError("output edges are not all dangling.")
+
+    net.nodes_set = set([final_node.reorder_edges(output_edge_order)])
     return net
-
-  # Then apply `opt_einsum`'s algorithm
-  nodes = sorted(net.nodes_set)
-  input_sets = utils.get_input_sets(net)
-  output_set = utils.get_output_set(net)
-  size_dict = utils.get_size_dict(net)
-  path = algorithm(input_sets, output_set, size_dict)
-  for a, b in path:
-    new_node = nodes[a] @ nodes[b]
-    nodes.append(new_node)
-    nodes = utils.multi_remove(nodes, [a, b])
-
-
-  # if the final node has more than one edge, output_edge_order has to be specified
-  final_node = net.get_final_node()
-  if (len(final_node.edges) <= 1) and (output_edge_order is None):
-    output_edge_order = list((net.get_all_edges() - net.get_all_nondangling()))
-  elif (len(final_node.edges) > 1) and (output_edge_order is None):
-    raise ValueError('if the final node has more than one dangling edge, `output_edge_order` has to be provided')
-    
-  if set(output_edge_order) != (net.get_all_edges() - net.get_all_nondangling()):
-    raise ValueError("output edges are not all dangling.")
-  
-  net.nodes_set = set([final_node.reorder_edges(output_edge_order)])
-  return net
 
 
 def optimal(net: network.TensorNetwork,
             output_edge_order: Sequence[network_components.Edge] = None,
             memory_limit: Optional[int] = None) -> network.TensorNetwork:
-  """Optimal contraction order via `opt_einsum`.
+    """Optimal contraction order via `opt_einsum`.
 
   This method will find the truly optimal contraction order via
   `opt_einsum`'s depth first search algorithm. Since this search is
@@ -87,23 +90,25 @@ def optimal(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
-                       are reordered into `output_edge_order`; if final node has more than one edge, 
+    output_edge_order: An optional list of edges. 
+                       Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; 
+                       if final node has more than one edge, 
                        `output_edge_order` must be provided.
     memory_limit: Maximum number of elements in an array during contractions.
 
   Returns:
     The network after full contraction.
   """
-  alg = functools.partial(opt_einsum.paths.optimal, memory_limit=memory_limit)
-  return base(net, alg, output_edge_order)
+    alg = functools.partial(opt_einsum.paths.optimal, memory_limit=memory_limit)
+    return base(net, alg, output_edge_order)
 
 
 def branch(net: network.TensorNetwork,
            output_edge_order: Sequence[network_components.Edge] = None,
            memory_limit: Optional[int] = None,
            nbranch: Optional[int] = None) -> network.TensorNetwork:
-  """Branch contraction path via `opt_einsum`.
+    """Branch contraction path via `opt_einsum`.
 
   This method uses the DFS approach of `optimal` while sorting potential
   contractions based on a heuristic cost, in order to reduce time spent
@@ -113,8 +118,10 @@ def branch(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
-                       are reordered into `output_edge_order`; if final node has more than one edge, 
+    output_edge_order: An optional list of edges. 
+                       Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; 
+                       if final node has more than one edge, 
                        `output_edge_order` must be provided.
     memory_limit: Maximum number of elements in an array during contractions.
     nbranch: Number of best contractions to explore.
@@ -124,15 +131,15 @@ def branch(net: network.TensorNetwork,
   Returns:
     The network after full contraction.
   """
-  alg = functools.partial(opt_einsum.paths.branch, memory_limit=memory_limit,
-                          nbranch=nbranch)
-  return base(net, alg, output_edge_order)  
+    alg = functools.partial(
+        opt_einsum.paths.branch, memory_limit=memory_limit, nbranch=nbranch)
+    return base(net, alg, output_edge_order)
 
 
 def greedy(net: network.TensorNetwork,
            output_edge_order: Sequence[network_components.Edge] = None,
            memory_limit: Optional[int] = None) -> network.TensorNetwork:
-  """Greedy contraction path via `opt_einsum`.
+    """Greedy contraction path via `opt_einsum`.
 
   This provides a more efficient strategy than `optimal` for finding
   contraction paths in large networks. First contracts pairs of tensors
@@ -143,65 +150,73 @@ def greedy(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
-                       are reordered into `output_edge_order`; if final node has more than one edge, 
+    output_edge_order: An optional list of edges. 
+                       Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; 
+                       if final node has more than one edge, 
                        `output_edge_order` must be provided.
     memory_limit: Maximum number of elements in an array during contractions.
 
   Returns:
     The network after full contraction.
   """
-  alg = functools.partial(opt_einsum.paths.greedy, memory_limit=memory_limit)
-  return base(net, alg, output_edge_order)  
+    alg = functools.partial(opt_einsum.paths.greedy, memory_limit=memory_limit)
+    return base(net, alg, output_edge_order)
 
 
 def auto(net: network.TensorNetwork,
          output_edge_order: Sequence[network_components.Edge] = None,
          memory_limit: Optional[int] = None) -> network.TensorNetwork:
-  """Chooses one of the above algorithms according to network size.
+    """Chooses one of the above algorithms according to network size.
 
   Default behavior is based on `opt_einsum`'s `auto` contractor.
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
-                       are reordered into `output_edge_order`; if final node has more than one edge, 
+    output_edge_order: An optional list of edges. 
+                       Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; 
+                       if final node has more than one edge, 
                        `output_edge_order` must be provided.
     memory_limit: Maximum number of elements in an array during contractions.
 
   Returns:
     The network after full contraction.
   """
-  n = len(net.nodes_set)
-  if n <= 0:
-    raise ValueError("Cannot contract empty tensor network.")
-  if n == 1:
-    edges = net.get_all_nondangling()
-    net.contract_parallel(edges.pop())
-    final_node = list(net.nodes_set)
-    if (len(final_node[0].edges) <= 1) and (output_edge_order is None):
-      output_edge_order = list((net.get_all_edges() - net.get_all_nondangling()))
-    elif (len(final_node[0].edges) > 1) and (output_edge_order is None):
-      raise ValueError('if the final node has more than one dangling edge, `output_edge_order` has to be provided')
+    n = len(net.nodes_set)
+    if n <= 0:
+        raise ValueError("Cannot contract empty tensor network.")
+    if n == 1:
+        edges = net.get_all_nondangling()
+        net.contract_parallel(edges.pop())
+        final_node = list(net.nodes_set)
+        if (len(final_node[0].edges) <= 1) and (output_edge_order is None):
+            output_edge_order = list(
+                (net.get_all_edges() - net.get_all_nondangling()))
+        elif (len(final_node[0].edges) > 1) and (output_edge_order is None):
+            raise ValueError(
+                'if the final node has more than one dangling edge, `output_edge_order` has to be provided'
+            )
 
-    net.nodes_set = set([list(net.nodes_set)[0].reorder_edges(output_edge_order)])
-    return net
-  if n < 5:
-    return optimal(net, output_edge_order, memory_limit)
-  if n < 7:
-    return branch(net, output_edge_order, memory_limit)
-  if n < 9:
-    return branch(net, output_edge_order, memory_limit, nbranch=2)
-  if n < 15:
-    return branch(net, output_edge_order, nbranch=1)
-  return greedy(net, output_edge_order, memory_limit)
+        net.nodes_set = set(
+            [list(net.nodes_set)[0].reorder_edges(output_edge_order)])
+        return net
+    if n < 5:
+        return optimal(net, output_edge_order, memory_limit)
+    if n < 7:
+        return branch(net, output_edge_order, memory_limit)
+    if n < 9:
+        return branch(net, output_edge_order, memory_limit, nbranch=2)
+    if n < 15:
+        return branch(net, output_edge_order, nbranch=1)
+    return greedy(net, output_edge_order, memory_limit)
 
 
 def custom(net: network.TensorNetwork,
            optimizer: Any,
            output_edge_order: Sequence[network_components.Edge] = None,
            memory_limit: Optional[int] = None) -> network.TensorNetwork:
-  """
+    """
   Uses a custom path optimizer created by the user to calculate paths.
 
   The custom path optimizer should inherit `opt_einsum`'s `PathOptimizer`.
@@ -210,8 +225,10 @@ def custom(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
-                       are reordered into `output_edge_order`; if final node has more than one edge, 
+    output_edge_order: An optional list of edges. 
+                       Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; 
+                       if final node has more than one edge, 
                        `output_edge_order` must be provided.
     optimizer: A custom `opt_einsum.PathOptimizer` object.
     memory_limit: Maximum number of elements in an array during contractions.
@@ -219,5 +236,5 @@ def custom(net: network.TensorNetwork,
   Returns:
     The network after full contraction.
   """
-  alg = functools.partial(optimizer, memory_limit=memory_limit)
-  return base(net, alg, output_edge_order)    
+    alg = functools.partial(optimizer, memory_limit=memory_limit)
+    return base(net, alg, output_edge_order)

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -1,3 +1,16 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Contractors based on `opt_einsum`'s path algorithms."""
 
 import functools

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -196,7 +196,8 @@ def auto(net: network.TensorNetwork,
                 (net.get_all_edges() - net.get_all_nondangling()))
         elif (len(final_node[0].edges) > 1) and (output_edge_order is None):
             raise ValueError(
-                'if the final node has more than one dangling edge, `output_edge_order` has to be provided'
+                "if the final node has more than one dangling edge"
+                ", `output_edge_order` has to be provided"
             )
 
         net.nodes_set = set(

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -1,0 +1,213 @@
+"""Contractors based on `opt_einsum`'s path algorithms."""
+
+import functools
+import opt_einsum
+from typing import Any, Callable, Dict, Optional, List, Set, Sequence
+from tensornetwork import network
+from tensornetwork import network_components
+from tensornetwork.contractors.opt_einsum_paths import utils
+
+
+def base(net: network.TensorNetwork,
+         algorithm: Callable[[List[Set[int]], Set[int], Dict[int, int]],
+                             List],
+         output_edge_order: Sequence[network_components.Edge] = None
+) -> network.TensorNetwork:
+  """Base method for all `opt_einsum` contractors.
+
+  Args:
+    net: a TensorNetwork object. Should be connected.
+    algorithm: `opt_einsum` contraction method to use.
+    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; if final node has more than one edge, 
+                       `output_edge_order` must be provided.
+  Returns:
+    The network after full contraction.
+  """
+
+  
+  net.check_connected()
+  # First contract all trace edges
+  edges = net.get_all_nondangling()
+  for edge in edges:
+    if edge in net and edge.is_trace():
+      net.contract_parallel(edge)
+  if not net.get_all_nondangling():
+    # There's nothing to contract.
+    return net
+
+  # Then apply `opt_einsum`'s algorithm
+  nodes = sorted(net.nodes_set)
+  input_sets = utils.get_input_sets(net)
+  output_set = utils.get_output_set(net)
+  size_dict = utils.get_size_dict(net)
+  path = algorithm(input_sets, output_set, size_dict)
+  for a, b in path:
+    new_node = nodes[a] @ nodes[b]
+    nodes.append(new_node)
+    nodes = utils.multi_remove(nodes, [a, b])
+
+
+  # if the final node has more than one edge, output_edge_order has to be specified
+  final_node = list(net.nodes_set)
+  if (len(final_node[0].edges) <= 1) and (output_edge_order is None):
+    output_edge_order = list((net.get_all_edges() - net.get_all_nondangling()))
+  elif (len(final_node[0].edges) > 1) and (output_edge_order is None):
+    raise ValueError('if the final node has more than one dangling edge, `output_edge_order` has to be provided')
+    
+  if set(output_edge_order) != (net.get_all_edges() - net.get_all_nondangling()):
+    raise ValueError("output edges are not all dangling.")
+  
+  final_node = list(net.nodes_set)
+  if len(final_node) > 1: #currently this should never be reached if the network is disconnected (opt_einsum doesn't support disconnected graphs yet)
+    raise ValueError('network is disconnected')
+  net.nodes_set = set([final_node[0].reorder_edges(output_edge_order)])
+  return net
+
+
+def optimal(net: network.TensorNetwork,
+            output_edge_order: Sequence[network_components.Edge] = None,
+            memory_limit: Optional[int] = None) -> network.TensorNetwork:
+  """Optimal contraction order via `opt_einsum`.
+
+  This method will find the truly optimal contraction order via
+  `opt_einsum`'s depth first search algorithm. Since this search is
+  exhaustive, if your network is large (n>10), then the search may
+  take longer than just contracting in a suboptimal way.
+
+  Args:
+    net: a TensorNetwork object.
+    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; if final node has more than one edge, 
+                       `output_edge_order` must be provided.
+    memory_limit: Maximum number of elements in an array during contractions.
+
+  Returns:
+    The network after full contraction.
+  """
+  alg = functools.partial(opt_einsum.paths.optimal, memory_limit=memory_limit)
+  return base(net, alg, output_edge_order)
+
+
+def branch(net: network.TensorNetwork,
+           output_edge_order: Sequence[network_components.Edge] = None,
+           memory_limit: Optional[int] = None,
+           nbranch: Optional[int] = None) -> network.TensorNetwork:
+  """Branch contraction path via `opt_einsum`.
+
+  This method uses the DFS approach of `optimal` while sorting potential
+  contractions based on a heuristic cost, in order to reduce time spent
+  in exploring paths which are unlikely to be optimal.
+  For more details:
+    https://optimized-einsum.readthedocs.io/en/latest/branching_path.html
+
+  Args:
+    net: a TensorNetwork object.
+    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; if final node has more than one edge, 
+                       `output_edge_order` must be provided.
+    memory_limit: Maximum number of elements in an array during contractions.
+    nbranch: Number of best contractions to explore.
+      If None it explores all inner products starting with those that
+      have the best cost heuristic.
+
+  Returns:
+    The network after full contraction.
+  """
+  alg = functools.partial(opt_einsum.paths.branch, memory_limit=memory_limit,
+                          nbranch=nbranch)
+  return base(net, alg, output_edge_order)  
+
+
+def greedy(net: network.TensorNetwork,
+           output_edge_order: Sequence[network_components.Edge] = None,
+           memory_limit: Optional[int] = None) -> network.TensorNetwork:
+  """Greedy contraction path via `opt_einsum`.
+
+  This provides a more efficient strategy than `optimal` for finding
+  contraction paths in large networks. First contracts pairs of tensors
+  by finding the pair with the lowest cost at each step. Then it performs
+  the outer products.
+  For more details:
+    https://optimized-einsum.readthedocs.io/en/latest/greedy_path.html
+
+  Args:
+    net: a TensorNetwork object.
+    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; if final node has more than one edge, 
+                       `output_edge_order` must be provided.
+    memory_limit: Maximum number of elements in an array during contractions.
+
+  Returns:
+    The network after full contraction.
+  """
+  alg = functools.partial(opt_einsum.paths.greedy, memory_limit=memory_limit)
+  return base(net, alg, output_edge_order)  
+
+
+def auto(net: network.TensorNetwork,
+         output_edge_order: Sequence[network_components.Edge] = None,
+         memory_limit: Optional[int] = None) -> network.TensorNetwork:
+  """Chooses one of the above algorithms according to network size.
+
+  Default behavior is based on `opt_einsum`'s `auto` contractor.
+
+  Args:
+    net: a TensorNetwork object.
+    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; if final node has more than one edge, 
+                       `output_edge_order` must be provided.
+    memory_limit: Maximum number of elements in an array during contractions.
+
+  Returns:
+    The network after full contraction.
+  """
+  n = len(net.nodes_set)
+  if n <= 0:
+    raise ValueError("Cannot contract empty tensor network.")
+  if n == 1:
+    edges = net.get_all_nondangling()
+    net.contract_parallel(edges.pop())
+    final_node = list(net.nodes_set)
+    if (len(final_node[0].edges) <= 1) and (output_edge_order is None):
+      output_edge_order = list((net.get_all_edges() - net.get_all_nondangling()))
+    elif (len(final_node[0].edges) > 1) and (output_edge_order is None):
+      raise ValueError('if the final node has more than one dangling edge, `output_edge_order` has to be provided')
+
+    net.nodes_set = set([list(net.nodes_set)[0].reorder_edges(output_edge_order)])
+    return net
+  if n < 5:
+    return optimal(net, output_edge_order, memory_limit)
+  if n < 7:
+    return branch(net, output_edge_order, memory_limit)
+  if n < 9:
+    return branch(net, output_edge_order, memory_limit, nbranch=2)
+  if n < 15:
+    return branch(net, output_edge_order, nbranch=1)
+  return greedy(net, output_edge_order, memory_limit)
+
+
+def custom(net: network.TensorNetwork,
+           optimizer: Any,
+           output_edge_order: Sequence[network_components.Edge] = None,
+           memory_limit: Optional[int] = None) -> network.TensorNetwork:
+  """
+  Uses a custom path optimizer created by the user to calculate paths.
+
+  The custom path optimizer should inherit `opt_einsum`'s `PathOptimizer`.
+  For more details:
+    https://optimized-einsum.readthedocs.io/en/latest/custom_paths.html
+
+  Args:
+    net: a TensorNetwork object.
+    output_edge_order: An optional list of edges. Edges of the final node in `nodes_set` 
+                       are reordered into `output_edge_order`; if final node has more than one edge, 
+                       `output_edge_order` must be provided.
+    optimizer: A custom `opt_einsum.PathOptimizer` object.
+    memory_limit: Maximum number of elements in an array during contractions.
+
+  Returns:
+    The network after full contraction.
+  """
+  alg = functools.partial(optimizer, memory_limit=memory_limit)
+  return base(net, alg, output_edge_order)    

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -62,19 +62,16 @@ def base(net: network.TensorNetwork,
 
 
   # if the final node has more than one edge, output_edge_order has to be specified
-  final_node = list(net.nodes_set)
-  if (len(final_node[0].edges) <= 1) and (output_edge_order is None):
+  final_node = net.get_final_node()
+  if (len(final_node.edges) <= 1) and (output_edge_order is None):
     output_edge_order = list((net.get_all_edges() - net.get_all_nondangling()))
-  elif (len(final_node[0].edges) > 1) and (output_edge_order is None):
+  elif (len(final_node.edges) > 1) and (output_edge_order is None):
     raise ValueError('if the final node has more than one dangling edge, `output_edge_order` has to be provided')
     
   if set(output_edge_order) != (net.get_all_edges() - net.get_all_nondangling()):
     raise ValueError("output edges are not all dangling.")
   
-  final_node = list(net.nodes_set)
-  if len(final_node) > 1: #currently this should never be reached if the network is disconnected (opt_einsum doesn't support disconnected graphs yet)
-    raise ValueError('network is disconnected')
-  net.nodes_set = set([final_node[0].reorder_edges(output_edge_order)])
+  net.nodes_set = set([final_node.reorder_edges(output_edge_order)])
   return net
 
 

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -67,7 +67,8 @@ def base(net: network.TensorNetwork,
             (net.get_all_edges() - net.get_all_nondangling()))
     elif (len(final_node.edges) > 1) and (output_edge_order is None):
         raise ValueError(
-            'if the final node has more than one dangling edge, `output_edge_order` has to be provided'
+            "if the final node has more than one dangling edge"
+            " `output_edge_order` has to be provided"
         )
 
     if set(output_edge_order) != (

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors_test.py
@@ -1,7 +1,23 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pytest
 import tensornetwork
 from tensornetwork.contractors.opt_einsum_paths import path_contractors
+import tensorflow as tf
+tf.enable_v2_behavior()
 
 
 @pytest.fixture(name="path_algorithm",

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors_test.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+import tensornetwork
+from tensornetwork.contractors.opt_einsum_paths import path_contractors
+
+
+@pytest.fixture(name="path_algorithm",
+                params=["optimal", "branch", "greedy", "auto"])
+def path_algorithm_fixture(request):
+  return getattr(path_contractors, request.param)
+
+
+def test_sanity_check(backend, path_algorithm):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.eye(2))
+  b = net.add_node(np.ones((2, 7, 11)))
+  c = net.add_node(np.ones((7, 11, 13, 2)))
+  d = net.add_node(np.eye(13))
+  # pylint: disable=pointless-statement
+  a[0] ^ b[0]
+  b[1] ^ c[0]
+  b[2] ^ c[1]
+  c[2] ^ d[1]
+  c[3] ^ a[1]
+  final_node = path_algorithm(net).get_final_node()
+  assert final_node.shape == (13,)
+
+
+def test_trace_edge(backend, path_algorithm):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.ones((2, 2, 2, 2, 2)))
+  b = net.add_node(np.ones((2, 2, 2)))
+  c = net.add_node(np.ones((2, 2, 2)))
+  # pylint: disable=pointless-statement
+  a[0] ^ a[1]
+  a[2] ^ b[0]
+  a[3] ^ c[0]
+  b[1] ^ c[1]
+  b[2] ^ c[2]
+  node = path_algorithm(net).get_final_node()
+  np.testing.assert_allclose(node.tensor, np.ones(2) * 32.0)
+
+
+def test_disconnected_network(backend, path_algorithm):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.array([2, 2]))
+  b = net.add_node(np.array([2, 2]))
+  c = net.add_node(np.array([2, 2]))
+  d = net.add_node(np.array([2, 2]))
+  # pylint: disable=pointless-statement
+  a[0] ^ b[0]
+  c[0] ^ d[0]
+  with pytest.raises(ValueError):
+    net = path_algorithm(net)
+
+
+def test_single_node(backend, path_algorithm):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.ones((2, 2, 2)))
+  # pylint: disable=pointless-statement
+  a[0] ^ a[1]
+  node = path_algorithm(net).get_final_node()
+  np.testing.assert_allclose(node.tensor, np.ones(2) * 2.0)
+
+
+def test_custom_sanity_check(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.ones(2))
+  b = net.add_node(np.ones((2, 5)))
+  # pylint: disable=pointless-statement
+  a[0] ^ b[0]
+
+  class PathOptimizer:
+
+    def __call__(self, inputs, output, size_dict, memory_limit=None):
+      return [(0, 1)]
+
+  optimizer = PathOptimizer()
+  final_node = path_contractors.custom(net, optimizer).get_final_node()
+  np.testing.assert_allclose(final_node.tensor, np.ones(5) * 2.0)

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors_test.py
@@ -20,77 +20,77 @@ import tensorflow as tf
 tf.enable_v2_behavior()
 
 
-@pytest.fixture(name="path_algorithm",
-                params=["optimal", "branch", "greedy", "auto"])
+@pytest.fixture(
+    name="path_algorithm", params=["optimal", "branch", "greedy", "auto"])
 def path_algorithm_fixture(request):
-  return getattr(path_contractors, request.param)
+    return getattr(path_contractors, request.param)
 
 
 def test_sanity_check(backend, path_algorithm):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.ones((2, 7, 11)))
-  c = net.add_node(np.ones((7, 11, 13, 2)))
-  d = net.add_node(np.eye(13))
-  # pylint: disable=pointless-statement
-  a[0] ^ b[0]
-  b[1] ^ c[0]
-  b[2] ^ c[1]
-  c[2] ^ d[1]
-  c[3] ^ a[1]
-  final_node = path_algorithm(net).get_final_node()
-  assert final_node.shape == (13,)
+    net = tensornetwork.TensorNetwork(backend=backend)
+    a = net.add_node(np.eye(2))
+    b = net.add_node(np.ones((2, 7, 11)))
+    c = net.add_node(np.ones((7, 11, 13, 2)))
+    d = net.add_node(np.eye(13))
+    # pylint: disable=pointless-statement
+    a[0] ^ b[0]
+    b[1] ^ c[0]
+    b[2] ^ c[1]
+    c[2] ^ d[1]
+    c[3] ^ a[1]
+    final_node = path_algorithm(net).get_final_node()
+    assert final_node.shape == (13,)
 
 
 def test_trace_edge(backend, path_algorithm):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2, 2, 2, 2)))
-  b = net.add_node(np.ones((2, 2, 2)))
-  c = net.add_node(np.ones((2, 2, 2)))
-  # pylint: disable=pointless-statement
-  a[0] ^ a[1]
-  a[2] ^ b[0]
-  a[3] ^ c[0]
-  b[1] ^ c[1]
-  b[2] ^ c[2]
-  node = path_algorithm(net).get_final_node()
-  np.testing.assert_allclose(node.tensor, np.ones(2) * 32.0)
+    net = tensornetwork.TensorNetwork(backend=backend)
+    a = net.add_node(np.ones((2, 2, 2, 2, 2)))
+    b = net.add_node(np.ones((2, 2, 2)))
+    c = net.add_node(np.ones((2, 2, 2)))
+    # pylint: disable=pointless-statement
+    a[0] ^ a[1]
+    a[2] ^ b[0]
+    a[3] ^ c[0]
+    b[1] ^ c[1]
+    b[2] ^ c[2]
+    node = path_algorithm(net).get_final_node()
+    np.testing.assert_allclose(node.tensor, np.ones(2) * 32.0)
 
 
 def test_disconnected_network(backend, path_algorithm):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([2, 2]))
-  b = net.add_node(np.array([2, 2]))
-  c = net.add_node(np.array([2, 2]))
-  d = net.add_node(np.array([2, 2]))
-  # pylint: disable=pointless-statement
-  a[0] ^ b[0]
-  c[0] ^ d[0]
-  with pytest.raises(ValueError):
-    net = path_algorithm(net)
+    net = tensornetwork.TensorNetwork(backend=backend)
+    a = net.add_node(np.array([2, 2]))
+    b = net.add_node(np.array([2, 2]))
+    c = net.add_node(np.array([2, 2]))
+    d = net.add_node(np.array([2, 2]))
+    # pylint: disable=pointless-statement
+    a[0] ^ b[0]
+    c[0] ^ d[0]
+    with pytest.raises(ValueError):
+        net = path_algorithm(net)
 
 
 def test_single_node(backend, path_algorithm):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2, 2)))
-  # pylint: disable=pointless-statement
-  a[0] ^ a[1]
-  node = path_algorithm(net).get_final_node()
-  np.testing.assert_allclose(node.tensor, np.ones(2) * 2.0)
+    net = tensornetwork.TensorNetwork(backend=backend)
+    a = net.add_node(np.ones((2, 2, 2)))
+    # pylint: disable=pointless-statement
+    a[0] ^ a[1]
+    node = path_algorithm(net).get_final_node()
+    np.testing.assert_allclose(node.tensor, np.ones(2) * 2.0)
 
 
 def test_custom_sanity_check(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones(2))
-  b = net.add_node(np.ones((2, 5)))
-  # pylint: disable=pointless-statement
-  a[0] ^ b[0]
+    net = tensornetwork.TensorNetwork(backend=backend)
+    a = net.add_node(np.ones(2))
+    b = net.add_node(np.ones((2, 5)))
+    # pylint: disable=pointless-statement
+    a[0] ^ b[0]
 
-  class PathOptimizer:
+    class PathOptimizer:
 
-    def __call__(self, inputs, output, size_dict, memory_limit=None):
-      return [(0, 1)]
+        def __call__(self, inputs, output, size_dict, memory_limit=None):
+            return [(0, 1)]
 
-  optimizer = PathOptimizer()
-  final_node = path_contractors.custom(net, optimizer).get_final_node()
-  np.testing.assert_allclose(final_node.tensor, np.ones(5) * 2.0)
+    optimizer = PathOptimizer()
+    final_node = path_contractors.custom(net, optimizer).get_final_node()
+    np.testing.assert_allclose(final_node.tensor, np.ones(5) * 2.0)


### PR DESCRIPTION
added `output_edge_order` to `opt_einsum` contractors.
If the final node after contraction has more than one dangling edge, the user
has to provide an edge-ordering for the resulting node