### PR TITLE
Adding slice notation for edges 

### DIFF
--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -1,5 +1,5 @@
 jax
 jaxlib
-pytype
+pytype>=2019.06.21
 pytest
 torch>=1.1

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -260,8 +260,13 @@ class Node:
   @overload
   def __getitem__(self, key: slice) -> List["Edge"]:
     return self.edges[key]
-
+  
+  @overload
   def __getitem__(self, key: Union[int, Text]) -> "Edge":
+    return self.get_edge(key)
+
+  def __getitem__(self, key: Union[int, Text, slice]
+                 ) -> Union["Edge", List["Edge"]]:
     if isinstance(key, slice):
       return self.edges[key]
     return self.get_edge(key)

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -16,7 +16,8 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from typing import Any, Dict, List, Optional, Set, Text, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Set, Text, Tuple, Type, Union, \
+  overload
 import typing
 import numpy as np
 from tensornetwork.backends import base_backend
@@ -256,7 +257,13 @@ class Node:
         return True
     return False
 
+  @overload
+  def __getitem__(self, key: slice) -> List["Edge"]:
+    return self.edges[key]
+
   def __getitem__(self, key: Union[int, Text]) -> "Edge":
+    if isinstance(key, slice):
+      return self.edges[key]
     return self.get_edge(key)
 
   def __str__(self) -> Text:

--- a/tensornetwork/network_components_test.py
+++ b/tensornetwork/network_components_test.py
@@ -201,8 +201,17 @@ def test_node_magic_getitem(single_node_edge):
   edge = single_node_edge.edge
   node.add_edge(edge, axis=0)
   assert node[0] == edge
-
-
+  
+  
+def test_node_magic_getslice(single_node_edge):
+  node = single_node_edge.node
+  edge = single_node_edge.edge 
+  node.add_edge(edge, axis=0)
+  assert node[:1][0] is edge 
+  assert len(node[None:None]) == 3 
+  assert len(node[0:3:2]) == 2 
+  
+  
 def test_node_magic_str(single_node_edge):
   node = single_node_edge.node
   assert str(node) == node.name


### PR DESCRIPTION
This adds the functionality of accessing edges like node[1:2], as discussed in issue #158.

Only integer slices work -- I thought about making node['a':'b'] work, for named axes, but this seems like functionality more likely to create bugs than to be useful. I can update the PR to include this functionality if anyone thinks otherwise, however.