### PR TITLE
split_node_qr and split_node_rq

### DIFF
--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -119,6 +119,30 @@ class BaseBackend:
     raise NotImplementedError(
         "Backend '{}' has not implemented svd_decomposition.".format(self.name))
 
+  def qr_decomposition(
+      np,  # TODO: Typing
+      tensor: Tensor,
+      split_axis: int,
+  ) -> Tuple[Tensor, Tensor]:
+    """Computes the QR decomposition of a tensor.
+
+    See tensornetwork.backends.tensorflow.decompositions for details.
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented qr_decomposition.".format(self.name))
+
+  def qr_decomposition(
+      np,  # TODO: Typing
+      tensor: Tensor,
+      split_axis: int,
+  ) -> Tuple[Tensor, Tensor]:
+    """Computes the RQ (reversed QR) decomposition of a tensor.
+    
+    See tensornetwork.backends.tensorflow.decompositions for details.
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented rq_decomposition.".format(self.name))
+
   def concat(self, values: Sequence[Tensor], axis) -> Tensor:
     """Concatenate a sequence of tensors together about the given axis."""
     raise NotImplementedError("Backend '{}' has not implemented concat.".format(

--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -119,7 +119,8 @@ class BaseBackend:
     raise NotImplementedError(
         "Backend '{}' has not implemented svd_decomposition.".format(self.name))
 
-  def qr_decomposition(self,
+  def qr_decomposition(
+      self,
       np,  # TODO: Typing
       tensor: Tensor,
       split_axis: int,
@@ -129,7 +130,8 @@ class BaseBackend:
     raise NotImplementedError(
         "Backend '{}' has not implemented qr_decomposition.".format(self.name))
 
-  def rq_decomposition(self,
+  def rq_decomposition(
+      self,
       np,  # TODO: Typing
       tensor: Tensor,
       split_axis: int,

--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -131,7 +131,7 @@ class BaseBackend:
     raise NotImplementedError(
         "Backend '{}' has not implemented qr_decomposition.".format(self.name))
 
-  def qr_decomposition(
+  def rq_decomposition(
       np,  # TODO: Typing
       tensor: Tensor,
       split_axis: int,

--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -119,7 +119,7 @@ class BaseBackend:
     raise NotImplementedError(
         "Backend '{}' has not implemented svd_decomposition.".format(self.name))
 
-  def qr_decomposition(
+  def qr_decomposition(self,
       np,  # TODO: Typing
       tensor: Tensor,
       split_axis: int,
@@ -129,7 +129,7 @@ class BaseBackend:
     raise NotImplementedError(
         "Backend '{}' has not implemented qr_decomposition.".format(self.name))
 
-  def rq_decomposition(
+  def rq_decomposition(self,
       np,  # TODO: Typing
       tensor: Tensor,
       split_axis: int,

--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -121,7 +121,6 @@ class BaseBackend:
 
   def qr_decomposition(
       self,
-      np,  # TODO: Typing
       tensor: Tensor,
       split_axis: int,
   ) -> Tuple[Tensor, Tensor]:
@@ -132,7 +131,6 @@ class BaseBackend:
 
   def rq_decomposition(
       self,
-      np,  # TODO: Typing
       tensor: Tensor,
       split_axis: int,
   ) -> Tuple[Tensor, Tensor]:

--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -125,8 +125,6 @@ class BaseBackend:
       split_axis: int,
   ) -> Tuple[Tensor, Tensor]:
     """Computes the QR decomposition of a tensor.
-
-    See tensornetwork.backends.tensorflow.decompositions for details.
     """
     raise NotImplementedError(
         "Backend '{}' has not implemented qr_decomposition.".format(self.name))
@@ -137,8 +135,6 @@ class BaseBackend:
       split_axis: int,
   ) -> Tuple[Tensor, Tensor]:
     """Computes the RQ (reversed QR) decomposition of a tensor.
-    
-    See tensornetwork.backends.tensorflow.decompositions for details.
     """
     raise NotImplementedError(
         "Backend '{}' has not implemented rq_decomposition.".format(self.name))

--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -75,13 +75,16 @@ def qr_decomposition(
     tensor: Tensor,
     split_axis: int,
 ) -> Tuple[Tensor, Tensor]:
-  """Computes the singular value decomposition (SVD) of a tensor.
+  """Computes the QR decomposition of a tensor.
 
   See tensornetwork.backends.tensorflow.decompositions for details.
   """
   left_dims = tensor.shape[:split_axis]
   right_dims = tensor.shape[split_axis:]
-
   tensor = np.reshape(tensor, [numpy.prod(left_dims), numpy.prod(right_dims)])
-  return np.linalg.qr(tensor)
+  q, r = np.linalg.qr(tensor)
+  center_dim = q.shape[1]
+  q = np.reshape(q, list(left_dims) + [center_dim])
+  r = np.reshape(r, [center_dim] + list(right_dims))
+  return q, r
 

--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -69,3 +69,19 @@ def svd_decomposition(
   vh = np.reshape(vh, [dim_s] + list(right_dims))
 
   return u, s, vh, s_rest
+
+def qr_decomposition(
+    np,  # TODO: Typing
+    tensor: Tensor,
+    split_axis: int,
+) -> Tuple[Tensor, Tensor]:
+  """Computes the singular value decomposition (SVD) of a tensor.
+
+  See tensornetwork.backends.tensorflow.decompositions for details.
+  """
+  left_dims = tensor.shape[:split_axis]
+  right_dims = tensor.shape[split_axis:]
+
+  tensor = np.reshape(tensor, [numpy.prod(left_dims), numpy.prod(right_dims)])
+  return np.linalg.qr(tensor)
+

--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -101,9 +101,8 @@ def rq_decomposition(
   right_dims = tensor.shape[split_axis:]
   tensor = np.reshape(tensor, [numpy.prod(left_dims), numpy.prod(right_dims)])
   q, r = np.linalg.qr(np.conj(np.transpose(tensor)))
-  r, q = np.conj(np.transpose(r)),np.conj(np.transpose(q))  #M=r*q at this point
+  r, q = np.conj(np.transpose(r)), np.conj(np.transpose(q))  #M=r*q at this point
   center_dim = r.shape[1]
   r = np.reshape(r, list(left_dims) + [center_dim])
   q = np.reshape(q, [center_dim] + list(right_dims))
   return r, q
-

--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -101,7 +101,7 @@ def rq_decomposition(
   right_dims = tensor.shape[split_axis:]
   tensor = np.reshape(tensor, [numpy.prod(left_dims), numpy.prod(right_dims)])
   q, r = np.linalg.qr(np.conj(np.transpose(tensor)))
-  r, q = np.conj(np.transpose(r)), np.conj(np.transpose(q))  #M=r*q at this point
+  r, q = np.conj(np.transpose(r)), np.conj(np.transpose(q))#M=r*q at this point
   center_dim = r.shape[1]
   r = np.reshape(r, list(left_dims) + [center_dim])
   q = np.reshape(q, [center_dim] + list(right_dims))

--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -88,3 +88,22 @@ def qr_decomposition(
   r = np.reshape(r, [center_dim] + list(right_dims))
   return q, r
 
+def rq_decomposition(
+    np,  # TODO: Typing
+    tensor: Tensor,
+    split_axis: int,
+) -> Tuple[Tensor, Tensor]:
+  """Computes the RQ (reversed QR) decomposition of a tensor.
+
+  See tensornetwork.backends.tensorflow.decompositions for details.
+  """
+  left_dims = tensor.shape[:split_axis]
+  right_dims = tensor.shape[split_axis:]
+  tensor = np.reshape(tensor, [numpy.prod(left_dims), numpy.prod(right_dims)])
+  q, r = np.linalg.qr(np.conj(np.transpose(tensor)))
+  r, q = np.conj(np.transpose(r)),np.conj(np.transpose(q))  #M=r*q at this point
+  center_dim = r.shape[1]
+  r = np.reshape(r, list(left_dims) + [center_dim])
+  q = np.reshape(q, [center_dim] + list(right_dims))
+  return r, q
+

--- a/tensornetwork/backends/numpy/decompositions_test.py
+++ b/tensornetwork/backends/numpy/decompositions_test.py
@@ -43,6 +43,19 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(r.shape, (2, 3, 6))
     self.assertEqual(q.shape, (6, 4, 5))
 
+  def test_rq_decomposition(self):
+    random_matrix = np.random.rand(10, 10)
+    r, q = decompositions.rq_decomposition(
+      np, random_matrix, 1)
+    self.assertAllClose(r.dot(q), random_matrix)
+    
+  def test_qr_decomposition(self):
+    random_matrix = np.random.rand(10, 10)
+    q, r = decompositions.qr_decomposition(
+      np, random_matrix, 1)
+    self.assertAllClose(q.dot(r), random_matrix)
+
+
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)
     unitary1, _, unitary2 = np.linalg.svd(random_matrix)

--- a/tensornetwork/backends/numpy/decompositions_test.py
+++ b/tensornetwork/backends/numpy/decompositions_test.py
@@ -30,6 +30,12 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(s.shape, (6,))
     self.assertAllClose(s, np.zeros(6))
     self.assertEqual(vh.shape, (6, 4, 5))
+    
+  def test_expected_shapes(self):
+    val = np.zeros((2, 3, 4, 5))
+    q, r = decompositions.qr_decomposition(np, val, 2)
+    self.assertEqual(q.shape, (2, 3, 6))
+    self.assertEqual(r.shape, (6, 4, 5))
 
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)

--- a/tensornetwork/backends/numpy/decompositions_test.py
+++ b/tensornetwork/backends/numpy/decompositions_test.py
@@ -30,13 +30,13 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(s.shape, (6,))
     self.assertAllClose(s, np.zeros(6))
     self.assertEqual(vh.shape, (6, 4, 5))
-    
+
   def test_expected_shapes_qr(self):
     val = np.zeros((2, 3, 4, 5))
     q, r = decompositions.qr_decomposition(np, val, 2)
     self.assertEqual(q.shape, (2, 3, 6))
     self.assertEqual(r.shape, (6, 4, 5))
-    
+
   def test_expected_shapes_rq(self):
     val = np.zeros((2, 3, 4, 5))
     r, q = decompositions.rq_decomposition(np, val, 2)
@@ -45,16 +45,13 @@ class DecompositionsTest(tf.test.TestCase):
 
   def test_rq_decomposition(self):
     random_matrix = np.random.rand(10, 10)
-    r, q = decompositions.rq_decomposition(
-      np, random_matrix, 1)
+    r, q = decompositions.rq_decomposition(np, random_matrix, 1)
     self.assertAllClose(r.dot(q), random_matrix)
-    
+
   def test_qr_decomposition(self):
     random_matrix = np.random.rand(10, 10)
-    q, r = decompositions.qr_decomposition(
-      np, random_matrix, 1)
+    q, r = decompositions.qr_decomposition(np, random_matrix, 1)
     self.assertAllClose(q.dot(r), random_matrix)
-
 
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)

--- a/tensornetwork/backends/numpy/decompositions_test.py
+++ b/tensornetwork/backends/numpy/decompositions_test.py
@@ -31,11 +31,17 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertAllClose(s, np.zeros(6))
     self.assertEqual(vh.shape, (6, 4, 5))
     
-  def test_expected_shapes(self):
+  def test_expected_shapes_qr(self):
     val = np.zeros((2, 3, 4, 5))
     q, r = decompositions.qr_decomposition(np, val, 2)
     self.assertEqual(q.shape, (2, 3, 6))
     self.assertEqual(r.shape, (6, 4, 5))
+    
+  def test_expected_shapes_rq(self):
+    val = np.zeros((2, 3, 4, 5))
+    r, q = decompositions.rq_decomposition(np, val, 2)
+    self.assertEqual(r.shape, (2, 3, 6))
+    self.assertEqual(q.shape, (6, 4, 5))
 
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -59,6 +59,12 @@ class NumPyBackend(base_backend.BaseBackend):
                        split_axis: int,
                        ) -> Tuple[Tensor, Tensor]:
     return self.decompositions.qr_decomposition(self.np, tensor, split_axis)
+
+  def rq_decomposition(self,
+                       tensor: Tensor,
+                       split_axis: int,
+                       ) -> Tuple[Tensor, Tensor]:
+    return self.decompositions.rq_decomposition(self.np, tensor, split_axis)
   
   def concat(self, values: Tensor, axis: int) -> Tensor:
     return self.np.concatenate(values, axis)

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -54,6 +54,12 @@ class NumPyBackend(base_backend.BaseBackend):
                                                  max_singular_values,
                                                  max_truncation_error)
 
+  def qr_decomposition(self,
+                       tensor: Tensor,
+                       split_axis: int,
+                       ) -> Tuple[Tensor, Tensor]:
+    return self.decompositions.qr_decomposition(self.np, tensor, split_axis)
+  
   def concat(self, values: Tensor, axis: int) -> Tensor:
     return self.np.concatenate(values, axis)
 

--- a/tensornetwork/backends/pytorch/decompositions.py
+++ b/tensornetwork/backends/pytorch/decompositions.py
@@ -121,14 +121,13 @@ def qr_decomposition(torch: Any,
                      ) -> Tuple[Tensor, Tensor]:
   """Computes the QR decomposition of a tensor.
 
-  The QR decomposition is performed by treating the tensor as a matrix, with an effective
-  left (row) index resulting from combining the axes `tensor.shape[:split_axis]`
-  and an effective right (column) index resulting from combining the axes
-  `tensor.shape[split_axis:]`.
+  The QR decomposition is performed by treating the tensor as a matrix, 
+  with an effective left (row) index resulting from combining the axes 
+  `tensor.shape[:split_axis]` and an effective right (column) index 
+  resulting from combining the axes `tensor.shape[split_axis:]`.
 
-  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, then
-  `u` would have shape (2, 3, 6), `s` would have shape (6), and `vh` would
-  have shape (6, 4, 5).
+  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, 
+  then `q` would have shape (2, 3, 6), and `r` would have shape (6, 4, 5).
 
   The output consists of two tensors `Q, R` such that:
   ```python
@@ -165,14 +164,13 @@ def rq_decomposition(torch: Any,
                      ) -> Tuple[Tensor, Tensor]:
   """Computes the RQ decomposition of a tensor.
 
-  The RQ decomposition is performed by treating the tensor as a matrix, with an effective
-  left (row) index resulting from combining the axes `tensor.shape[:split_axis]`
-  and an effective right (column) index resulting from combining the axes
-  `tensor.shape[split_axis:]`.
+  The RQ decomposition is performed by treating the tensor as a matrix, 
+  with an effective left (row) index resulting from combining the axes 
+  `tensor.shape[:split_axis]` and an effective right (column) index 
+  resulting from combining the axes `tensor.shape[split_axis:]`.
 
-  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, then
-  `u` would have shape (2, 3, 6), `s` would have shape (6), and `vh` would
-  have shape (6, 4, 5).
+  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, 
+  then `r` would have shape (2, 3, 6), and `q` would have shape (6, 4, 5).
 
   The output consists of two tensors `R, Q` such that:
   ```python
@@ -196,7 +194,7 @@ def rq_decomposition(torch: Any,
   right_dims = tensor.shape[split_axis:]
   tensor = torch.reshape(tensor, [np.prod(left_dims), np.prod(right_dims)])
   q, r = torch.qr(torch.transpose(tensor, 0, 1)) #torch has currently no support for complex dtypes
-  r, q = torch.transpose(r, 0, 1),torch.transpose(q, 0, 1)  #M=r*q at this point
+  r, q = torch.transpose(r, 0, 1), torch.transpose(q, 0, 1)  #M=r*q at this point
   center_dim = r.shape[1]
   r = torch.reshape(r, list(left_dims) + [center_dim])
   q = torch.reshape(q, [center_dim] + list(right_dims))

--- a/tensornetwork/backends/pytorch/decompositions.py
+++ b/tensornetwork/backends/pytorch/decompositions.py
@@ -151,7 +151,7 @@ def qr_decomposition(torch: Any,
   right_dims = list(tensor.shape)[split_axis:]
 
   tensor = torch.reshape(tensor, (np.prod(left_dims), np.prod(right_dims)))
-  q,r = torch.qr(tensor)
+  q, r = torch.qr(tensor)
   center_dim = q.shape[1]
   q = torch.reshape(q, list(left_dims) + [center_dim])
   r = torch.reshape(r, [center_dim] + list(right_dims))
@@ -193,8 +193,9 @@ def rq_decomposition(torch: Any,
   left_dims = tensor.shape[:split_axis]
   right_dims = tensor.shape[split_axis:]
   tensor = torch.reshape(tensor, [np.prod(left_dims), np.prod(right_dims)])
-  q, r = torch.qr(torch.transpose(tensor, 0, 1)) #torch has currently no support for complex dtypes
-  r, q = torch.transpose(r, 0, 1), torch.transpose(q, 0, 1)  #M=r*q at this point
+  #torch has currently no support for complex dtypes  
+  q, r = torch.qr(torch.transpose(tensor, 0, 1)) 
+  r, q = torch.transpose(r, 0, 1), torch.transpose(q, 0, 1)#M=r*q at this point
   center_dim = r.shape[1]
   r = torch.reshape(r, list(left_dims) + [center_dim])
   q = torch.reshape(q, [center_dim] + list(right_dims))

--- a/tensornetwork/backends/pytorch/decompositions.py
+++ b/tensornetwork/backends/pytorch/decompositions.py
@@ -114,3 +114,44 @@ def svd_decomposition(torch: Any,
   vh = torch.reshape(vh, [dim_s] + right_dims)
 
   return u, s, vh, s_rest
+
+def qr_decomposition(torch: Any,
+                     tensor: Tensor,
+                     split_axis: int,
+                     ) -> Tuple[Tensor, Tensor]:
+  """Computes the QR decomposition (SVD) of a tensor.
+
+  The QR decomposition is performed by treating the tensor as a matrix, with an effective
+  left (row) index resulting from combining the axes `tensor.shape[:split_axis]`
+  and an effective right (column) index resulting from combining the axes
+  `tensor.shape[split_axis:]`.
+
+  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, then
+  `u` would have shape (2, 3, 6), `s` would have shape (6), and `vh` would
+  have shape (6, 4, 5).
+
+  The output consists of two tensors `Q, R` such that:
+  ```python
+    Q[i1,...,iN, j] * R[j, k1,...,kM] == tensor[i1,...,iN, k1,...,kM]
+  ```
+  Note that the output ordering matches numpy.linalg.svd rather than tf.svd.
+
+  Args:
+    tf: The tensorflow module.
+    tensor: A tensor to be decomposed.
+    split_axis: Where to split the tensor's axes before flattening into a
+      matrix.
+
+  Returns:
+    Q: Left tensor factor.
+    R: Right tensor factor.
+  """
+
+  left_dims = list(tensor.shape)[:split_axis]
+  right_dims = list(tensor.shape)[split_axis:]
+
+  tensor = torch.reshape(tensor, (np.prod(left_dims), np.prod(right_dims)))
+  return torch.qr(tensor)
+
+
+

--- a/tensornetwork/backends/pytorch/decompositions.py
+++ b/tensornetwork/backends/pytorch/decompositions.py
@@ -151,7 +151,12 @@ def qr_decomposition(torch: Any,
   right_dims = list(tensor.shape)[split_axis:]
 
   tensor = torch.reshape(tensor, (np.prod(left_dims), np.prod(right_dims)))
-  return torch.qr(tensor)
+  q,r = torch.qr(tensor)
+  center_dim = q.shape[1]
+  q = torch.reshape(q, list(left_dims) + [center_dim])
+  r = torch.reshape(r, [center_dim] + list(right_dims))
+  return q, r
+
 
 
 

--- a/tensornetwork/backends/pytorch/decompositions_test.py
+++ b/tensornetwork/backends/pytorch/decompositions_test.py
@@ -35,6 +35,13 @@ def test_expected_shapes_qr():
   assert q.shape == (2, 3, 6)
   assert r.shape == (6, 4, 5)  
 
+def test_expected_shapes_rq():
+  val = torch.zeros((2, 3, 4, 5))
+  r, q = decompositions.rq_decomposition(torch, val, 2)
+  assert r.shape == (2, 3, 6)
+  assert q.shape == (6, 4, 5)  
+
+  
 def test_max_singular_values():
   np.random.seed(2018)
   random_matrix = np.random.rand(10, 10)

--- a/tensornetwork/backends/pytorch/decompositions_test.py
+++ b/tensornetwork/backends/pytorch/decompositions_test.py
@@ -29,31 +29,33 @@ def test_expected_shapes():
   np.testing.assert_allclose(s, np.zeros(6))
   assert vh.shape == (6, 4, 5)
 
+
 def test_expected_shapes_qr():
   val = torch.zeros((2, 3, 4, 5))
   q, r = decompositions.qr_decomposition(torch, val, 2)
   assert q.shape == (2, 3, 6)
-  assert r.shape == (6, 4, 5)  
+  assert r.shape == (6, 4, 5)
+
 
 def test_expected_shapes_rq():
   val = torch.zeros((2, 3, 4, 5))
   r, q = decompositions.rq_decomposition(torch, val, 2)
   assert r.shape == (2, 3, 6)
   assert q.shape == (6, 4, 5)
-  
+
+
 def test_rq_decomposition():
   random_matrix = torch.rand([10, 10], dtype=torch.float64)
-  r, q = decompositions.rq_decomposition(
-    torch, random_matrix, 1)
+  r, q = decompositions.rq_decomposition(torch, random_matrix, 1)
   np.testing.assert_allclose(r.mm(q), random_matrix)
-    
+
+
 def test_qr_decomposition():
-  random_matrix = torch.rand([10, 10], dtype=torch.float64)  
-  q, r = decompositions.qr_decomposition(
-    torch, random_matrix, 1)
+  random_matrix = torch.rand([10, 10], dtype=torch.float64)
+  q, r = decompositions.qr_decomposition(torch, random_matrix, 1)
   np.testing.assert_allclose(q.mm(r), random_matrix)
 
-  
+
 def test_max_singular_values():
   np.random.seed(2018)
   random_matrix = np.random.rand(10, 10)

--- a/tensornetwork/backends/pytorch/decompositions_test.py
+++ b/tensornetwork/backends/pytorch/decompositions_test.py
@@ -29,6 +29,11 @@ def test_expected_shapes():
   np.testing.assert_allclose(s, np.zeros(6))
   assert vh.shape == (6, 4, 5)
 
+def test_expected_shapes_qr():
+  val = torch.zeros((2, 3, 4, 5))
+  q, r = decompositions.qr_decomposition(torch, val, 2)
+  assert q.shape == (2, 3, 6)
+  assert r.shape == (6, 4, 5)  
 
 def test_max_singular_values():
   np.random.seed(2018)

--- a/tensornetwork/backends/pytorch/decompositions_test.py
+++ b/tensornetwork/backends/pytorch/decompositions_test.py
@@ -39,7 +39,19 @@ def test_expected_shapes_rq():
   val = torch.zeros((2, 3, 4, 5))
   r, q = decompositions.rq_decomposition(torch, val, 2)
   assert r.shape == (2, 3, 6)
-  assert q.shape == (6, 4, 5)  
+  assert q.shape == (6, 4, 5)
+  
+def test_rq_decomposition():
+  random_matrix = torch.rand([10, 10], dtype=torch.float64)
+  r, q = decompositions.rq_decomposition(
+    torch, random_matrix, 1)
+  np.testing.assert_allclose(r.mm(q), random_matrix)
+    
+def test_qr_decomposition():
+  random_matrix = torch.rand([10, 10], dtype=torch.float64)  
+  q, r = decompositions.qr_decomposition(
+    torch, random_matrix, 1)
+  np.testing.assert_allclose(q.mm(r), random_matrix)
 
   
 def test_max_singular_values():

--- a/tensornetwork/backends/pytorch/pytorch_backend.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend.py
@@ -54,6 +54,11 @@ class PyTorchBackend(base_backend.BaseBackend):
     return decompositions.svd_decomposition(self.torch, tensor, split_axis,
                                             max_singular_values,
                                             max_truncation_error)
+  def qr_decomposition(self,
+                       tensor: Tensor,
+                       split_axis: int,
+                       ) -> Tuple[Tensor, Tensor]:
+    return decompositions.qr_decomposition(self.torch, tensor, split_axis)
 
   def concat(self, values: Tensor, axis: int) -> Tensor:
     return np.concatenate(values, axis)

--- a/tensornetwork/backends/pytorch/pytorch_backend.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend.py
@@ -59,6 +59,12 @@ class PyTorchBackend(base_backend.BaseBackend):
                        split_axis: int,
                        ) -> Tuple[Tensor, Tensor]:
     return decompositions.qr_decomposition(self.torch, tensor, split_axis)
+  
+  def rq_decomposition(self,
+                       tensor: Tensor,
+                       split_axis: int,
+                       ) -> Tuple[Tensor, Tensor]:
+    return decompositions.rq_decomposition(self.torch, tensor, split_axis)
 
   def concat(self, values: Tensor, axis: int) -> Tensor:
     return np.concatenate(values, axis)

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -91,6 +91,8 @@ class ShellBackend(base_backend.BaseBackend):
   def qr_decomposition(self, tensor: Tensor,
                        split_axis: int) -> Tuple[Tensor, Tensor]:
 
+    left_dims = tensor.shape[:split_axis]
+    right_dims = tensor.shape[split_axis:]
     center_dim = min(tensor.shape)
     q = ShellTensor(left_dims + (center_dim,))
     r = ShellTensor((center_dim,) + right_dims)
@@ -99,6 +101,8 @@ class ShellBackend(base_backend.BaseBackend):
   def rq_decomposition(self, tensor: Tensor,
                        split_axis: int) -> Tuple[Tensor, Tensor]:
 
+    left_dims = tensor.shape[:split_axis]
+    right_dims = tensor.shape[split_axis:]
     center_dim = min(tensor.shape)
     q = ShellTensor(left_dims + (center_dim,))
     r = ShellTensor((center_dim,) + right_dims)

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -88,6 +88,26 @@ class ShellBackend(base_backend.BaseBackend):
     s_rest = ShellTensor((dim_s0 - dim_s,))
     return u, s, vh, s_rest
 
+  def qr_decomposition(self,
+                       tensor: Tensor,
+                       split_axis: int
+                      ) -> Tuple[Tensor, Tensor]:
+
+    center_dim = min(tensor.shape)
+    q = ShellTensor(left_dims + (center_dim,))
+    r = ShellTensor((center_dim,) + right_dims)
+    return q, r 
+  
+  def rq_decomposition(self,
+                       tensor: Tensor,
+                       split_axis: int
+                      ) -> Tuple[Tensor, Tensor]:
+
+    center_dim = min(tensor.shape)
+    q = ShellTensor(left_dims + (center_dim,))
+    r = ShellTensor((center_dim,) + right_dims)
+    return q, r 
+  
   def concat(self, values: Sequence[Tensor], axis: int) -> Tensor:
     shape = values[0].shape
     if axis < 0:

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -88,26 +88,22 @@ class ShellBackend(base_backend.BaseBackend):
     s_rest = ShellTensor((dim_s0 - dim_s,))
     return u, s, vh, s_rest
 
-  def qr_decomposition(self,
-                       tensor: Tensor,
-                       split_axis: int
-                      ) -> Tuple[Tensor, Tensor]:
+  def qr_decomposition(self, tensor: Tensor,
+                       split_axis: int) -> Tuple[Tensor, Tensor]:
 
     center_dim = min(tensor.shape)
     q = ShellTensor(left_dims + (center_dim,))
     r = ShellTensor((center_dim,) + right_dims)
-    return q, r 
-  
-  def rq_decomposition(self,
-                       tensor: Tensor,
-                       split_axis: int
-                      ) -> Tuple[Tensor, Tensor]:
+    return q, r
+
+  def rq_decomposition(self, tensor: Tensor,
+                       split_axis: int) -> Tuple[Tensor, Tensor]:
 
     center_dim = min(tensor.shape)
     q = ShellTensor(left_dims + (center_dim,))
     r = ShellTensor((center_dim,) + right_dims)
-    return q, r 
-  
+    return q, r
+
   def concat(self, values: Sequence[Tensor], axis: int) -> Tensor:
     shape = values[0].shape
     if axis < 0:

--- a/tensornetwork/backends/tensorflow/decompositions.py
+++ b/tensornetwork/backends/tensorflow/decompositions.py
@@ -159,8 +159,51 @@ def qr_decomposition(tf: Any,
                        tf.reduce_prod(right_dims)])
   q, r = tf.linalg.qr(tensor)
   center_dim = tf.shape(q)[1]
-  q = np.reshape(q, list(left_dims) + [center_dim])
-  r = np.reshape(r, [center_dim] + list(right_dims))
+  q = tf.reshape(q, list(left_dims) + [center_dim])
+  r = tf.reshape(r, [center_dim] + list(right_dims))
   return q, r
 
 
+def rq_decomposition(tf: Any,
+                     tensor: Tensor,
+                     split_axis: int,
+                     ) -> Tuple[Tensor, Tensor]:
+  """Computes the QR decomposition (SVD) of a tensor.
+
+  The QR decomposition is performed by treating the tensor as a matrix, with an effective
+  left (row) index resulting from combining the axes `tensor.shape[:split_axis]`
+  and an effective right (column) index resulting from combining the axes
+  `tensor.shape[split_axis:]`.
+
+  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, then
+  `u` would have shape (2, 3, 6), `s` would have shape (6), and `vh` would
+  have shape (6, 4, 5).
+
+  The output consists of two tensors `Q, R` such that:
+  ```python
+    Q[i1,...,iN, j] * R[j, k1,...,kM] == tensor[i1,...,iN, k1,...,kM]
+  ```
+  Note that the output ordering matches numpy.linalg.svd rather than tf.svd.
+
+  Args:
+    tf: The tensorflow module.
+    tensor: A tensor to be decomposed.
+    split_axis: Where to split the tensor's axes before flattening into a
+      matrix.
+
+  Returns:
+    Q: Left tensor factor.
+    R: Right tensor factor.
+  """
+  left_dims = tf.shape(tensor)[:split_axis]
+  right_dims = tf.shape(tensor)[split_axis:]
+
+  tensor = tf.reshape(tensor,
+                      [tf.reduce_prod(left_dims),
+                       tf.reduce_prod(right_dims)])
+  q, r = tf.linalg.qr(tf.conj(tf.transpose(tensor)))
+  r, q = tf.conj(tf.transpose(r)),tf.conj(tf.transpose(q))  #M=r*q at this point
+  center_dim = tf.shape(r)[1]
+  r = tf.reshape(r, list(left_dims) + [center_dim])
+  q = tf.reshape(q, [center_dim] + list(right_dims))
+  return r, q

--- a/tensornetwork/backends/tensorflow/decompositions.py
+++ b/tensornetwork/backends/tensorflow/decompositions.py
@@ -124,15 +124,15 @@ def qr_decomposition(tf: Any,
                      tensor: Tensor,
                      split_axis: int,
                      ) -> Tuple[Tensor, Tensor]:
-  """Computes the QR decomposition (SVD) of a tensor.
+  """Computes the QR decomposition of a tensor.
 
-  The QR decomposition is performed by treating the tensor as a matrix, with an effective
-  left (row) index resulting from combining the axes `tensor.shape[:split_axis]`
-  and an effective right (column) index resulting from combining the axes
-  `tensor.shape[split_axis:]`.
+  The QR decomposition is performed by treating the tensor as a matrix, 
+  with an effective left (row) index resulting from combining the 
+  axes `tensor.shape[:split_axis]` and an effective right (column) 
+  index resulting from combining the axes `tensor.shape[split_axis:]`.
 
-  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, then
-  `u` would have shape (2, 3, 6), `s` would have shape (6), and `vh` would
+  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, 
+  then `q` would have shape (2, 3, 6), and `r` would
   have shape (6, 4, 5).
 
   The output consists of two tensors `Q, R` such that:
@@ -168,15 +168,15 @@ def rq_decomposition(tf: Any,
                      tensor: Tensor,
                      split_axis: int,
                      ) -> Tuple[Tensor, Tensor]:
-  """Computes the QR decomposition (SVD) of a tensor.
+  """Computes the RQ decomposition of a tensor.
 
-  The QR decomposition is performed by treating the tensor as a matrix, with an effective
-  left (row) index resulting from combining the axes `tensor.shape[:split_axis]`
-  and an effective right (column) index resulting from combining the axes
-  `tensor.shape[split_axis:]`.
+  The QR decomposition is performed by treating the tensor as a matrix, 
+  with an effective left (row) index resulting from combining the axes 
+  `tensor.shape[:split_axis]` and an effective right (column) index 
+  resulting from combining the axes `tensor.shape[split_axis:]`.
 
-  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, then
-  `u` would have shape (2, 3, 6), `s` would have shape (6), and `vh` would
+  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, 
+  then `r` would have shape (2, 3, 6), and `q` would
   have shape (6, 4, 5).
 
   The output consists of two tensors `Q, R` such that:
@@ -202,7 +202,7 @@ def rq_decomposition(tf: Any,
                       [tf.reduce_prod(left_dims),
                        tf.reduce_prod(right_dims)])
   q, r = tf.linalg.qr(tf.conj(tf.transpose(tensor)))
-  r, q = tf.conj(tf.transpose(r)),tf.conj(tf.transpose(q))  #M=r*q at this point
+  r, q = tf.conj(tf.transpose(r)), tf.conj(tf.transpose(q))  #M=r*q at this point
   center_dim = tf.shape(r)[1]
   r = tf.reshape(r, list(left_dims) + [center_dim])
   q = tf.reshape(q, [center_dim] + list(right_dims))

--- a/tensornetwork/backends/tensorflow/decompositions.py
+++ b/tensornetwork/backends/tensorflow/decompositions.py
@@ -117,3 +117,46 @@ def svd_decomposition(tf: Any,
   vh = tf.reshape(vh, tf.concat([[dim_s], right_dims], axis=-1))
 
   return u, s, vh, s_rest
+
+
+
+def qr_decomposition(tf: Any,
+                     tensor: Tensor,
+                     split_axis: int,
+                     ) -> Tuple[Tensor, Tensor]:
+  """Computes the QR decomposition (SVD) of a tensor.
+
+  The QR decomposition is performed by treating the tensor as a matrix, with an effective
+  left (row) index resulting from combining the axes `tensor.shape[:split_axis]`
+  and an effective right (column) index resulting from combining the axes
+  `tensor.shape[split_axis:]`.
+
+  For example, if `tensor` had a shape (2, 3, 4, 5) and `split_axis` was 2, then
+  `u` would have shape (2, 3, 6), `s` would have shape (6), and `vh` would
+  have shape (6, 4, 5).
+
+  The output consists of two tensors `Q, R` such that:
+  ```python
+    Q[i1,...,iN, j] * R[j, k1,...,kM] == tensor[i1,...,iN, k1,...,kM]
+  ```
+  Note that the output ordering matches numpy.linalg.svd rather than tf.svd.
+
+  Args:
+    tf: The tensorflow module.
+    tensor: A tensor to be decomposed.
+    split_axis: Where to split the tensor's axes before flattening into a
+      matrix.
+
+  Returns:
+    Q: Left tensor factor.
+    R: Right tensor factor.
+  """
+  left_dims = tf.shape(tensor)[:split_axis]
+  right_dims = tf.shape(tensor)[split_axis:]
+
+  tensor = tf.reshape(tensor,
+                      [tf.reduce_prod(left_dims),
+                       tf.reduce_prod(right_dims)])
+  return tf.linalg.qr(tensor)
+
+

--- a/tensornetwork/backends/tensorflow/decompositions.py
+++ b/tensornetwork/backends/tensorflow/decompositions.py
@@ -157,6 +157,10 @@ def qr_decomposition(tf: Any,
   tensor = tf.reshape(tensor,
                       [tf.reduce_prod(left_dims),
                        tf.reduce_prod(right_dims)])
-  return tf.linalg.qr(tensor)
+  q, r = tf.linalg.qr(tensor)
+  center_dim = tf.shape(q)[1]
+  q = np.reshape(q, list(left_dims) + [center_dim])
+  r = np.reshape(r, [center_dim] + list(right_dims))
+  return q, r
 
 

--- a/tensornetwork/backends/tensorflow/decompositions.py
+++ b/tensornetwork/backends/tensorflow/decompositions.py
@@ -202,7 +202,7 @@ def rq_decomposition(tf: Any,
                       [tf.reduce_prod(left_dims),
                        tf.reduce_prod(right_dims)])
   q, r = tf.linalg.qr(tf.conj(tf.transpose(tensor)))
-  r, q = tf.conj(tf.transpose(r)), tf.conj(tf.transpose(q))  #M=r*q at this point
+  r, q = tf.conj(tf.transpose(r)), tf.conj(tf.transpose(q))#M=r*q at this point
   center_dim = tf.shape(r)[1]
   r = tf.reshape(r, list(left_dims) + [center_dim])
   q = tf.reshape(q, [center_dim] + list(right_dims))

--- a/tensornetwork/backends/tensorflow/decompositions_test.py
+++ b/tensornetwork/backends/tensorflow/decompositions_test.py
@@ -30,6 +30,12 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(s.shape, (6,))
     self.assertAllClose(s, np.zeros(6))
     self.assertEqual(vh.shape, (6, 4, 5))
+    
+  def test_expected_shapes_qr(self):
+    val = tf.zeros((2, 3, 4, 5))
+    q, r = decompositions.qr_decomposition(tf, val, 2)
+    self.assertEqual(q.shape, (2, 3, 6))
+    self.assertEqual(r.shape, (6, 4, 5))
 
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)

--- a/tensornetwork/backends/tensorflow/decompositions_test.py
+++ b/tensornetwork/backends/tensorflow/decompositions_test.py
@@ -37,6 +37,12 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(q.shape, (2, 3, 6))
     self.assertEqual(r.shape, (6, 4, 5))
 
+  def test_expected_shapes_rq(self):
+    val = tf.zeros((2, 3, 4, 5))
+    r, q = decompositions.rq_decomposition(tf, val, 2)
+    self.assertEqual(r.shape, (2, 3, 6))
+    self.assertEqual(q.shape, (6, 4, 5))
+    
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)
     unitary1, _, unitary2 = np.linalg.svd(random_matrix)

--- a/tensornetwork/backends/tensorflow/decompositions_test.py
+++ b/tensornetwork/backends/tensorflow/decompositions_test.py
@@ -42,6 +42,20 @@ class DecompositionsTest(tf.test.TestCase):
     r, q = decompositions.rq_decomposition(tf, val, 2)
     self.assertEqual(r.shape, (2, 3, 6))
     self.assertEqual(q.shape, (6, 4, 5))
+
+  def test_rq_decomposition(self):
+    random_matrix = np.random.rand(10, 10)    
+    r, q = decompositions.rq_decomposition(
+      tf, random_matrix, 1)
+    self.assertAllClose(tf.tensordot(r,q,([1],[0])), random_matrix)    
+
+    
+  def test_qr_decomposition(self):
+    random_matrix = np.random.rand(10, 10)    
+    q, r = decompositions.qr_decomposition(
+      tf, random_matrix, 1)
+    self.assertAllClose(tf.tensordot(q,r,([1],[0])), random_matrix)
+    
     
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)

--- a/tensornetwork/backends/tensorflow/decompositions_test.py
+++ b/tensornetwork/backends/tensorflow/decompositions_test.py
@@ -30,7 +30,7 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(s.shape, (6,))
     self.assertAllClose(s, np.zeros(6))
     self.assertEqual(vh.shape, (6, 4, 5))
-    
+
   def test_expected_shapes_qr(self):
     val = tf.zeros((2, 3, 4, 5))
     q, r = decompositions.qr_decomposition(tf, val, 2)
@@ -44,19 +44,15 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(q.shape, (6, 4, 5))
 
   def test_rq_decomposition(self):
-    random_matrix = np.random.rand(10, 10)    
-    r, q = decompositions.rq_decomposition(
-      tf, random_matrix, 1)
-    self.assertAllClose(tf.tensordot(r,q,([1],[0])), random_matrix)    
+    random_matrix = np.random.rand(10, 10)
+    r, q = decompositions.rq_decomposition(tf, random_matrix, 1)
+    self.assertAllClose(tf.tensordot(r, q, ([1], [0])), random_matrix)
 
-    
   def test_qr_decomposition(self):
-    random_matrix = np.random.rand(10, 10)    
-    q, r = decompositions.qr_decomposition(
-      tf, random_matrix, 1)
-    self.assertAllClose(tf.tensordot(q,r,([1],[0])), random_matrix)
-    
-    
+    random_matrix = np.random.rand(10, 10)
+    q, r = decompositions.qr_decomposition(tf, random_matrix, 1)
+    self.assertAllClose(tf.tensordot(q, r, ([1], [0])), random_matrix)
+
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)
     unitary1, _, unitary2 = np.linalg.svd(random_matrix)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -56,6 +56,12 @@ class TensorFlowBackend(base_backend.BaseBackend):
     return decompositions.svd_decomposition(self.tf, tensor, split_axis,
                                             max_singular_values,
                                             max_truncation_error)
+  def qr_decomposition(self,
+                       tensor: Tensor,
+                       split_axis: int
+                      ) -> Tuple[Tensor, Tensor]:
+    return decompositions.qr_decomposition(self.tf, tensor, split_axis)
+
 
   def concat(self, values: Tensor, axis: int) -> Tensor:
     return self.tf.concat(values, axis)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -61,6 +61,12 @@ class TensorFlowBackend(base_backend.BaseBackend):
                        split_axis: int
                       ) -> Tuple[Tensor, Tensor]:
     return decompositions.qr_decomposition(self.tf, tensor, split_axis)
+  
+  def rq_decomposition(self,
+                       tensor: Tensor,
+                       split_axis: int
+                      ) -> Tuple[Tensor, Tensor]:
+    return decompositions.rq_decomposition(self.tf, tensor, split_axis)
 
 
   def concat(self, values: Tensor, axis: int) -> Tensor:

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -862,7 +862,9 @@ class TensorNetwork:
       left_edges: List[network_components.Edge],
       right_edges: List[network_components.Edge],
       max_singular_values: Optional[int] = None,
-      max_truncation_err: Optional[float] = None
+      max_truncation_err: Optional[float] = None,
+      left_name: Optional[Text] = None,
+      right_name: Optional[Text] = None
   ) -> Tuple[network_components.BaseNode, network_components.BaseNode, Tensor]:
     """Split a network_components.BaseNode using Singular Value Decomposition.
 
@@ -919,11 +921,11 @@ class TensorNetwork:
     sqrt_s_broadcast_shape = self.backend.concat(
         [self.backend.shape(sqrt_s), [1] * (len(vh.shape) - 1)], axis=-1)
     vh_s = vh * self.backend.reshape(sqrt_s, sqrt_s_broadcast_shape)
-    left_node = self.add_node(u_s)
+    left_node = self.add_node(u_s,name=left_name)
     for i, edge in enumerate(left_edges):
       left_node.add_edge(edge, i)
       edge.update_axis(i, node, i, left_node)
-    right_node = self.add_node(vh_s)
+    right_node = self.add_node(vh_s, name=right_name)
     for i, edge in enumerate(right_edges):
       # i + 1 to account for the new edge.
       right_node.add_edge(edge, i + 1)

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -990,7 +990,10 @@ class TensorNetwork:
                           left_edges: List[network_components.Edge],
                           right_edges: List[network_components.Edge],
                           max_singular_values: Optional[int] = None,
-                          max_truncation_err: Optional[float] = None
+                          max_truncation_err: Optional[float] = None,
+                          left_name: Optional[Text] = None,
+                          middle_name: Optional[Text] = None,      
+                          right_name: Optional[Text] = None
                          ) -> Tuple[network_components.BaseNode,
                                     network_components.BaseNode,
                                     network_components.BaseNode, Tensor]:
@@ -1044,9 +1047,9 @@ class TensorNetwork:
     node.reorder_edges(left_edges + right_edges)
     u, s, vh, trun_vals = self.backend.svd_decomposition(
         node.tensor, len(left_edges), max_singular_values, max_truncation_err)
-    left_node = self.add_node(u)
-    singular_values_node = self.add_node(self.backend.diag(s))
-    right_node = self.add_node(vh)
+    left_node = self.add_node(u, name=left_name)
+    singular_values_node = self.add_node(self.backend.diag(s), name=middle_name)
+    right_node = self.add_node(vh, name=right_name)
     for i, edge in enumerate(left_edges):
       left_node.add_edge(edge, i)
       edge.update_axis(i, node, i, left_node)

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -897,6 +897,10 @@ class TensorNetwork:
       right_edges: The edges you want connected to the new right node.
       max_singular_values: The maximum number of singular values to keep.
       max_truncation_err: The maximum allowed truncation error.
+      left_name: The name of the new left node. If None, a name will be generated
+        automatically.
+      right_name: The name of the new right node. If None, a name will be generated
+        automatically.
 
     Returns:
       A tuple containing:
@@ -1029,6 +1033,12 @@ class TensorNetwork:
       right_edges: The edges you want connected to the new right node.
       max_singular_values: The maximum number of singular values to keep.
       max_truncation_err: The maximum allowed truncation error.
+      left_name: The name of the new left node. If None, a name will be generated
+        automatically.
+      middle_name: The name of the new center node. If None, a name will be generated
+        automatically.
+      right_name: The name of the new right node. If None, a name will be generated
+        automatically.
 
     Returns:
       A tuple containing:

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -866,7 +866,7 @@ class TensorNetwork:
       left_name: Optional[Text] = None,
       right_name: Optional[Text] = None
   ) -> Tuple[network_components.BaseNode, network_components.BaseNode, Tensor]:
-    """Split a network_components.BaseNode using Singular Value Decomposition.
+    """Split a `Node` using Singular Value Decomposition.
 
     Let M be the matrix created by flattening left_edges and right_edges into
     2 axes. Let :math:`U S V^* = M` be the Singular Value Decomposition of 
@@ -897,9 +897,9 @@ class TensorNetwork:
       right_edges: The edges you want connected to the new right node.
       max_singular_values: The maximum number of singular values to keep.
       max_truncation_err: The maximum allowed truncation error.
-      left_name: The name of the new left node. If None, a name will be generated
+      left_name: The name of the new left node. If `None`, a name will be generated
         automatically.
-      right_name: The name of the new right node. If None, a name will be generated
+      right_name: The name of the new right node. If `None`, a name will be generated
         automatically.
 
     Returns:
@@ -947,7 +947,7 @@ class TensorNetwork:
       left_name: Optional[Text] = None,
       right_name: Optional[Text] = None,      
   ) -> Tuple[network_components.BaseNode, network_components.BaseNode]:
-    """Split a network_components.BaseNode using QR decomposition
+    """Split a `Node` using QR decomposition
 
     Let M be the matrix created by flattening left_edges and right_edges into
     2 axes. Let :math:`QR = M` be the QR Decomposition of 
@@ -959,9 +959,9 @@ class TensorNetwork:
       node: The node you want to split.
       left_edges: The edges you want connected to the new left node.
       right_edges: The edges you want connected to the new right node.
-      left_name: The name of the new left node. If None, a name will be generated
+      left_name: The name of the new left node. If `None`, a name will be generated
         automatically.
-      right_name: The name of the new right node. If None, a name will be generated
+      right_name: The name of the new right node. If `None`, a name will be generated
         automatically.
 
     Returns:
@@ -996,7 +996,7 @@ class TensorNetwork:
       left_name: Optional[Text] = None,
       right_name: Optional[Text] = None,      
   ) -> Tuple[network_components.BaseNode, network_components.BaseNode]:
-    """Split a network_components.BaseNode using RQ (reversed QR) decomposition
+    """Split a `Node` using RQ (reversed QR) decomposition
 
     Let M be the matrix created by flattening left_edges and right_edges into
     2 axes. Let :math:`QR = M^*` be the QR Decomposition of 
@@ -1008,9 +1008,9 @@ class TensorNetwork:
       node: The node you want to split.
       left_edges: The edges you want connected to the new left node.
       right_edges: The edges you want connected to the new right node.
-      left_name: The name of the new left node. If None, a name will be generated
+      left_name: The name of the new left node. If `None`, a name will be generated
         automatically.
-      right_name: The name of the new right node. If None, a name will be generated
+      right_name: The name of the new right node. If `None`, a name will be generated
         automatically.
 
     Returns:

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -952,8 +952,57 @@ class TensorNetwork:
     Let M be the matrix created by flattening left_edges and right_edges into
     2 axes. Let :math:`QR = M` be the QR Decomposition of 
     :math:`M`. This will split the network into 2 nodes. The left node's 
-    tensor will be :math:`Q` and the right node's tensor will be 
-    :math:`R` where :math:`R`.
+    tensor will be :math:`Q` (an orthonormal matrix) and the right node's tensor will be 
+    :math:`R` (an upper triangular matrix)
+
+    Args:
+      node: The node you want to split.
+      left_edges: The edges you want connected to the new left node.
+      right_edges: The edges you want connected to the new right node.
+      left_name: The name of the new left node. If None, a name will be generated
+        automatically.
+      right_name: The name of the new right node. If None, a name will be generated
+        automatically.
+
+    Returns:
+      A tuple containing:
+        left_node: 
+          A new node created that connects to all of the `left_edges`.
+          Its underlying tensor is :math:`Q`
+        right_node: 
+          A new node created that connects to all of the `right_edges`.
+          Its underlying tensor is :math:`R`
+    """
+    node.reorder_edges(left_edges + right_edges)
+    q, r = self.backend.qr_decomposition(node.tensor, len(left_edges))
+    left_node = self.add_node(q, name=left_name)
+    for i, edge in enumerate(left_edges):
+      left_node.add_edge(edge, i)
+      edge.update_axis(i, node, i, left_node)
+    right_node = self.add_node(r, name=right_name)
+    for i, edge in enumerate(right_edges):
+      # i + 1 to account for the new edge.
+      right_node.add_edge(edge, i + 1)
+      edge.update_axis(i + len(left_edges), node, i + 1, right_node)
+    self.connect(left_node[-1], right_node[0])
+    self.nodes_set.remove(node)
+    return left_node, right_node
+  
+  def split_node_rq(
+      self,
+      node: network_components.BaseNode,
+      left_edges: List[network_components.Edge],
+      right_edges: List[network_components.Edge],
+      left_name: Optional[Text] = None,
+      right_name: Optional[Text] = None,      
+  ) -> Tuple[network_components.BaseNode, network_components.BaseNode]:
+    """Split a network_components.BaseNode using RQ (reversed QR) decomposition
+
+    Let M be the matrix created by flattening left_edges and right_edges into
+    2 axes. Let :math:`QR = M^*` be the QR Decomposition of 
+    :math:`M^*`. This will split the network into 2 nodes. The left node's 
+    tensor will be :math:`R^*` (a lower triangular matrix) and the right node's tensor will be 
+    :math:`Q^*` (an orthonormal matrix)
 
     Args:
       node: The node you want to split.

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -925,7 +925,7 @@ class TensorNetwork:
     sqrt_s_broadcast_shape = self.backend.concat(
         [self.backend.shape(sqrt_s), [1] * (len(vh.shape) - 1)], axis=-1)
     vh_s = vh * self.backend.reshape(sqrt_s, sqrt_s_broadcast_shape)
-    left_node = self.add_node(u_s,name=left_name)
+    left_node = self.add_node(u_s, name=left_name)
     for i, edge in enumerate(left_edges):
       left_node.add_edge(edge, i)
       edge.update_axis(i, node, i, left_node)

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -1208,6 +1208,7 @@ def test_remove_after_flatten(backend):
   net.flatten_all_edges()
   net.remove_node(a)
 
+
 def test_split_node_rq_names(backend):
   net = tensornetwork.TensorNetwork(backend=backend)
   a = net.add_node(np.zeros((2, 3, 4, 5, 6)))
@@ -1217,9 +1218,11 @@ def test_split_node_rq_names(backend):
   right_edges = []
   for i in range(3, 5):
     right_edges.append(a[i])
-  left, right = net.split_node_rq(a, left_edges, right_edges, left_name='left', right_name='right')
+  left, right = net.split_node_rq(
+      a, left_edges, right_edges, left_name='left', right_name='right')
   assert left.name == 'left'
-  assert right.name == 'right'  
+  assert right.name == 'right'
+
 
 def test_split_node_qr_names(backend):
   net = tensornetwork.TensorNetwork(backend=backend)
@@ -1230,9 +1233,11 @@ def test_split_node_qr_names(backend):
   right_edges = []
   for i in range(3, 5):
     right_edges.append(a[i])
-  left, right = net.split_node_qr(a, left_edges, right_edges, left_name='left', right_name='right')
+  left, right = net.split_node_qr(
+      a, left_edges, right_edges, left_name='left', right_name='right')
   assert left.name == 'left'
-  assert right.name == 'right'  
+  assert right.name == 'right'
+
 
 def test_split_node_names(backend):
   net = tensornetwork.TensorNetwork(backend=backend)
@@ -1243,9 +1248,11 @@ def test_split_node_names(backend):
   right_edges = []
   for i in range(3, 5):
     right_edges.append(a[i])
-  left, right, _ = net.split_node(a, left_edges, right_edges, left_name='left', right_name='right')
+  left, right, _ = net.split_node(
+      a, left_edges, right_edges, left_name='left', right_name='right')
   assert left.name == 'left'
   assert right.name == 'right'
+
 
 def test_split_node_rq(backend):
   net = tensornetwork.TensorNetwork(backend=backend)
@@ -1260,6 +1267,7 @@ def test_split_node_rq(backend):
   net.check_correct()
   np.testing.assert_allclose(a.tensor, net.contract(left[3]).tensor)
 
+
 def test_split_node_qr(backend):
   net = tensornetwork.TensorNetwork(backend=backend)
   a = net.add_node(np.random.rand(2, 3, 4, 5, 6))
@@ -1272,6 +1280,3 @@ def test_split_node_qr(backend):
   left, right = net.split_node_qr(a, left_edges, right_edges)
   net.check_correct()
   np.testing.assert_allclose(a.tensor, net.contract(left[3]).tensor)
-
-  
-

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -1263,7 +1263,7 @@ def test_split_node_rq(backend):
   right_edges = []
   for i in range(3, 5):
     right_edges.append(a[i])
-  left, right = net.split_node_rq(a, left_edges, right_edges)
+  left, _ = net.split_node_rq(a, left_edges, right_edges)
   net.check_correct()
   np.testing.assert_allclose(a.tensor, net.contract(left[3]).tensor)
 
@@ -1277,6 +1277,6 @@ def test_split_node_qr(backend):
   right_edges = []
   for i in range(3, 5):
     right_edges.append(a[i])
-  left, right = net.split_node_qr(a, left_edges, right_edges)
+  left, _ = net.split_node_qr(a, left_edges, right_edges)
   net.check_correct()
   np.testing.assert_allclose(a.tensor, net.contract(left[3]).tensor)

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -1245,5 +1245,33 @@ def test_split_node_names(backend):
     right_edges.append(a[i])
   left, right, _ = net.split_node(a, left_edges, right_edges, left_name='left', right_name='right')
   assert left.name == 'left'
-  assert right.name == 'right'  
+  assert right.name == 'right'
+
+def test_split_node_rq(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.random.rand(2, 3, 4, 5, 6))
+  left_edges = []
+  for i in range(3):
+    left_edges.append(a[i])
+  right_edges = []
+  for i in range(3, 5):
+    right_edges.append(a[i])
+  left, right = net.split_node_rq(a, left_edges, right_edges)
+  net.check_correct()
+  np.testing.assert_allclose(a.tensor, net.contract(left[3]).tensor)
+
+def test_split_node_qr(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.random.rand(2, 3, 4, 5, 6))
+  left_edges = []
+  for i in range(3):
+    left_edges.append(a[i])
+  right_edges = []
+  for i in range(3, 5):
+    right_edges.append(a[i])
+  left, right = net.split_node_qr(a, left_edges, right_edges)
+  net.check_correct()
+  np.testing.assert_allclose(a.tensor, net.contract(left[3]).tensor)
+
+  
 

--- a/tensornetwork/tensornetwork_test.py
+++ b/tensornetwork/tensornetwork_test.py
@@ -1207,3 +1207,43 @@ def test_remove_after_flatten(backend):
   net.connect(a[1], b[1])
   net.flatten_all_edges()
   net.remove_node(a)
+
+def test_split_node_rq_names(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.zeros((2, 3, 4, 5, 6)))
+  left_edges = []
+  for i in range(3):
+    left_edges.append(a[i])
+  right_edges = []
+  for i in range(3, 5):
+    right_edges.append(a[i])
+  left, right = net.split_node_rq(a, left_edges, right_edges, left_name='left', right_name='right')
+  assert left.name == 'left'
+  assert right.name == 'right'  
+
+def test_split_node_qr_names(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.zeros((2, 3, 4, 5, 6)))
+  left_edges = []
+  for i in range(3):
+    left_edges.append(a[i])
+  right_edges = []
+  for i in range(3, 5):
+    right_edges.append(a[i])
+  left, right = net.split_node_qr(a, left_edges, right_edges, left_name='left', right_name='right')
+  assert left.name == 'left'
+  assert right.name == 'right'  
+
+def test_split_node_names(backend):
+  net = tensornetwork.TensorNetwork(backend=backend)
+  a = net.add_node(np.zeros((2, 3, 4, 5, 6)))
+  left_edges = []
+  for i in range(3):
+    left_edges.append(a[i])
+  right_edges = []
+  for i in range(3, 5):
+    right_edges.append(a[i])
+  left, right, _ = net.split_node(a, left_edges, right_edges, left_name='left', right_name='right')
+  assert left.name == 'left'
+  assert right.name == 'right'  
+


### PR DESCRIPTION
This PR implements `TensorNetwork.split_node_qr` and `TensorNetwork.split_node_rq`
- `TensorNetwork.split_node_qr` splits a node into two nodes `Q` and `R`  such that `N=Q*R` using a `QR` decomposition, with `R` an upper triangular matrix and `Q` an orthonormal matrix
- `TensorNetwork.split_node_rq` splits a node `N` into two nodes `R` and `Q` such that `N=R*Q `using a `QR` decomposition, with `R` a lower triangular matrix and `Q` an orthonormal matrix
- `TensorNetwork.split_node` and `TensorNetwork.split_node_full_svd` now accept optional naming arguments for the newly created nodes