### PR TITLE
Refactor opt_einsum contractors and test paths

### DIFF
--- a/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
@@ -31,9 +31,9 @@ def check_path(calculated_path, correct_path):
     return False
 
   ret = True
-  for pos in range(len(calculated_path)):
-    ret &= isinstance(calculated_path[pos], tuple)
-    ret &= calculated_path[pos] == correct_path[pos]
+  for calc, correct in zip(calculated_path, correct_path):
+    ret &= isinstance(calc, tuple)
+    ret &= calc == correct
   return ret
 
 
@@ -104,6 +104,5 @@ def test_path_optimal(params):
   net = globals()[network_name]()
   path_algorithm = getattr(opt_einsum.paths, algorithm_name)
 
-  calculated_path, sorted_nodes = utils.get_path(net, path_algorithm)
-  assert sorted_nodes == sorted(net.nodes_set, key=lambda n: n.signature)
+  calculated_path = utils.get_path(net, path_algorithm)
   assert check_path(calculated_path, correct_path)

--- a/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
@@ -1,0 +1,71 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests contraction paths calculated by `utils.gate_path`.
+
+These tests are based on `opt_einsum`s tests from
+github.com/dgasmith/opt_einsum/blob/master/opt_einsum/tests/test_paths.py
+"""
+import numpy as np
+import opt_einsum
+import pytest
+import tensornetwork
+from tensornetwork.contractors.opt_einsum_paths import utils
+
+
+@pytest.fixture(name="path_algorithm",
+                params=["optimal", "branch", "greedy"])
+def path_algorithm_fixture(request):
+  return getattr(opt_einsum.paths, request.param)
+
+
+def check_path(calculated_path, correct_path, bypass=False):
+  if not isinstance(calculated_path, list):
+    return False
+
+  if len(calculated_path) != len(correct_path):
+    return False
+
+  ret = True
+  for pos in range(len(calculated_path)):
+    ret &= isinstance(calculated_path[pos], tuple)
+    ret &= calculated_path[pos] == correct_path[pos]
+  return ret
+
+
+def create_tensor_network():
+  """Creates 'GEMM1' contraction from `opt_einsum` tests in `TensorNetowrk`.
+
+  Note that the optimal contraction order is [(0, 2), (0, 1)].
+  """
+  net = tensornetwork.TensorNetwork()
+  x = net.add_node(np.ones([1, 2, 4]))
+  y = net.add_node(np.ones([1, 3]))
+  z = net.add_node(np.ones([2, 4, 3]))
+  # pylint: disable=pointless-statement
+  x[0] ^ y[0]
+  x[1] ^ z[0]
+  x[2] ^ z[1]
+  y[1] ^ z[2]
+
+  # This ordering is compatible with `TensorNetwork` only if we sort
+  # according to `node.signature`!
+  optimal_order = [(0, 2), (0, 1)]
+  return net, optimal_order
+
+
+def test_path_optimal(path_algorithm):
+  net, optimal_order = create_tensor_network()
+  calculated_path, sorted_nodes = utils.get_path(net, path_algorithm)
+  assert sorted_nodes == sorted(net.nodes_set, key = lambda n: n.signature)
+  assert check_path(calculated_path, optimal_order)

--- a/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
@@ -76,8 +76,9 @@ def matrix_chain():
   net = tensornetwork.TensorNetwork()
   d = [10, 8, 6, 4, 2]
   nodes = [net.add_node(np.ones([d1, d2])) for d1, d2 in zip(d[:-1], d[1:])]
-  for i in range(len(d) - 2):
-    nodes[i][1] ^ nodes[i + 1][0]
+  for a, b in zip(nodes[:-1], nodes[1:]):
+    # pylint: disable=pointless-statement
+    a[1] ^ b[0]
   return net
 
 
@@ -104,5 +105,5 @@ def test_path_optimal(params):
   path_algorithm = getattr(opt_einsum.paths, algorithm_name)
 
   calculated_path, sorted_nodes = utils.get_path(net, path_algorithm)
-  assert sorted_nodes == sorted(net.nodes_set, key = lambda n: n.signature)
+  assert sorted_nodes == sorted(net.nodes_set, key=lambda n: n.signature)
   assert check_path(calculated_path, correct_path)

--- a/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
@@ -104,5 +104,5 @@ def test_path_optimal(params):
   net = globals()[network_name]()
   path_algorithm = getattr(opt_einsum.paths, algorithm_name)
 
-  calculated_path = utils.get_path(net, path_algorithm)
+  calculated_path, _ = utils.get_path(net, path_algorithm)
   assert check_path(calculated_path, correct_path)

--- a/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_calculation_test.py
@@ -23,13 +23,7 @@ import tensornetwork
 from tensornetwork.contractors.opt_einsum_paths import utils
 
 
-@pytest.fixture(name="path_algorithm",
-                params=["optimal", "branch", "greedy"])
-def path_algorithm_fixture(request):
-  return getattr(opt_einsum.paths, request.param)
-
-
-def check_path(calculated_path, correct_path, bypass=False):
+def check_path(calculated_path, correct_path):
   if not isinstance(calculated_path, list):
     return False
 
@@ -43,11 +37,11 @@ def check_path(calculated_path, correct_path, bypass=False):
   return ret
 
 
-def create_tensor_network():
-  """Creates 'GEMM1' contraction from `opt_einsum` tests in `TensorNetowrk`.
-
-  Note that the optimal contraction order is [(0, 2), (0, 1)].
-  """
+# We do not use the backend fixture as this file tests only contraction paths
+# that `opt_einsum` returns and not the actual contractions performed by
+# `TensorNetwork`.
+def gemm_network():
+  """Creates 'GEMM1' contraction from `opt_einsum` tests."""
   net = tensornetwork.TensorNetwork()
   x = net.add_node(np.ones([1, 2, 4]))
   y = net.add_node(np.ones([1, 3]))
@@ -57,15 +51,58 @@ def create_tensor_network():
   x[1] ^ z[0]
   x[2] ^ z[1]
   y[1] ^ z[2]
-
-  # This ordering is compatible with `TensorNetwork` only if we sort
-  # according to `node.signature`!
-  optimal_order = [(0, 2), (0, 1)]
-  return net, optimal_order
+  return net
 
 
-def test_path_optimal(path_algorithm):
-  net, optimal_order = create_tensor_network()
+def inner_network():
+  """Creates a (modified) `Inner1` contraction from `opt_einsum` tests."""
+  net = tensornetwork.TensorNetwork()
+  x = net.add_node(np.ones([5, 2, 3, 4]))
+  y = net.add_node(np.ones([5, 3]))
+  z = net.add_node(np.ones([2, 4]))
+  # pylint: disable=pointless-statement
+  x[0] ^ y[0]
+  x[1] ^ z[0]
+  x[2] ^ y[1]
+  x[3] ^ z[1]
+  return net
+
+
+def matrix_chain():
+  """Creates a contraction of chain of matrices.
+
+  The `greedy` algorithm does not find the optimal path in this case!
+  """
+  net = tensornetwork.TensorNetwork()
+  d = [10, 8, 6, 4, 2]
+  nodes = [net.add_node(np.ones([d1, d2])) for d1, d2 in zip(d[:-1], d[1:])]
+  for i in range(len(d) - 2):
+    nodes[i][1] ^ nodes[i + 1][0]
+  return net
+
+
+# Parametrize tests by giving:
+# (contraction algorithm, network, correct path that is expected)
+test_list = [
+    ("optimal", "gemm_network", [(0, 2), (0, 1)]),
+    ("branch", "gemm_network", [(0, 2), (0, 1)]),
+    ("greedy", "gemm_network", [(0, 2), (0, 1)]),
+    ("optimal", "inner_network", [(0, 1), (0, 1)]),
+    ("branch", "inner_network", [(0, 1), (0, 1)]),
+    ("greedy", "inner_network", [(0, 1), (0, 1)]),
+    ("optimal", "matrix_chain", [(2, 3), (1, 2), (0, 1)]),
+    ("branch", "matrix_chain", [(2, 3), (1, 2), (0, 1)]),
+    ("greedy", "matrix_chain", [(0, 1), (0, 2), (0, 1)]),
+    ]
+
+
+@pytest.mark.parametrize("params", test_list)
+def test_path_optimal(params):
+  algorithm_name, network_name, correct_path = params
+
+  net = globals()[network_name]()
+  path_algorithm = getattr(opt_einsum.paths, algorithm_name)
+
   calculated_path, sorted_nodes = utils.get_path(net, path_algorithm)
   assert sorted_nodes == sorted(net.nodes_set, key = lambda n: n.signature)
-  assert check_path(calculated_path, optimal_order)
+  assert check_path(calculated_path, correct_path)

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -49,8 +49,7 @@ def base(net: network.TensorNetwork, algorithm: utils.Algorithm,
     return net
 
   # Then apply `opt_einsum`'s algorithm
-  path = utils.get_path(net, algorithm)
-  nodes = sorted(net.nodes_set, key=lambda n: n.signature)
+  path, nodes = utils.get_path(net, algorithm)
   for a, b in path:
     new_node = nodes[a] @ nodes[b]
     nodes.append(new_node)

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -51,7 +51,7 @@ def base(net: network.TensorNetwork, algorithm: utils.Algorithm,
   # Then apply `opt_einsum`'s algorithm
   path = utils.get_path(net, algorithm)
 
-  nodes = sorted(net.nodes_set)
+  nodes = sorted(net.nodes_set, key = lambda n: n.signature)
   for a, b in path:
     new_node = nodes[a] @ nodes[b]
     nodes.append(new_node)

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -49,7 +49,8 @@ def base(net: network.TensorNetwork, algorithm: utils.Algorithm,
     return net
 
   # Then apply `opt_einsum`'s algorithm
-  path, nodes = utils.get_path(net, algorithm)
+  path = utils.get_path(net, algorithm)
+  nodes = sorted(net.nodes_set, key=lambda n: n.signature)
   for a, b in path:
     new_node = nodes[a] @ nodes[b]
     nodes.append(new_node)

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -15,30 +15,29 @@
 
 import functools
 import opt_einsum
-from typing import Any, Callable, Dict, Optional, List, Set, Sequence
 from tensornetwork import network
 from tensornetwork import network_components
 from tensornetwork.contractors.opt_einsum_paths import utils
+from typing import Any, Optional, Sequence
 
 
-def base(net: network.TensorNetwork,
-         algorithm: Callable[[List[Set[int]], Set[int], Dict[int, int]], List],
+def base(net: network.TensorNetwork, algorithm: utils.Algorithm,
          output_edge_order: Optional[Sequence[network_components.Edge]] = None
-        ) -> network.TensorNetwork:
+         ) -> network.TensorNetwork:
   """Base method for all `opt_einsum` contractors.
 
   Args:
     net: a TensorNetwork object. Should be connected.
     algorithm: `opt_einsum` contraction method to use.
-    output_edge_order: An optional list of edges. Edges of the 
-      final node in `nodes_set` 
-      are reordered into `output_edge_order`; 
-      if final node has more than one edge, 
+    output_edge_order: An optional list of edges. Edges of the
+      final node in `nodes_set`
+      are reordered into `output_edge_order`;
+      if final node has more than one edge,
       `output_edge_order` must be provided.
+
   Returns:
     The network after full contraction.
   """
-
   net.check_connected()
   # First contract all trace edges
   edges = net.get_all_nondangling()
@@ -50,11 +49,9 @@ def base(net: network.TensorNetwork,
     return net
 
   # Then apply `opt_einsum`'s algorithm
+  path = utils.get_path(net, algorithm)
+
   nodes = sorted(net.nodes_set)
-  input_sets = utils.get_input_sets(net)
-  output_set = utils.get_output_set(net)
-  size_dict = utils.get_size_dict(net)
-  path = algorithm(input_sets, output_set, size_dict)
   for a, b in path:
     new_node = nodes[a] @ nodes[b]
     nodes.append(new_node)
@@ -90,10 +87,10 @@ def optimal(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. 
-      Edges of the final node in `nodes_set` 
-      are reordered into `output_edge_order`; 
-      if final node has more than one edge, 
+    output_edge_order: An optional list of edges.
+      Edges of the final node in `nodes_set`
+      are reordered into `output_edge_order`;
+      if final node has more than one edge,
       `output_edge_order` must be provided.
     memory_limit: Maximum number of elements in an array during contractions.
 
@@ -118,10 +115,10 @@ def branch(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. 
-      Edges of the final node in `nodes_set` 
-       are reordered into `output_edge_order`; 
-       if final node has more than one edge, 
+    output_edge_order: An optional list of edges.
+      Edges of the final node in `nodes_set`
+       are reordered into `output_edge_order`;
+       if final node has more than one edge,
        `output_edge_order` must be provided.
     memory_limit: Maximum number of elements in an array during contractions.
     nbranch: Number of best contractions to explore.
@@ -150,10 +147,10 @@ def greedy(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. 
-      Edges of the final node in `nodes_set` 
-      are reordered into `output_edge_order`; 
-      if final node has more than one edge, 
+    output_edge_order: An optional list of edges.
+      Edges of the final node in `nodes_set`
+      are reordered into `output_edge_order`;
+      if final node has more than one edge,
       `output_edge_order` must be provided.
     memory_limit: Maximum number of elements in an array during contractions.
 
@@ -173,10 +170,10 @@ def auto(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. 
-      Edges of the final node in `nodes_set` 
-      are reordered into `output_edge_order`; 
-      if final node has more than one edge, 
+    output_edge_order: An optional list of edges.
+      Edges of the final node in `nodes_set`
+      are reordered into `output_edge_order`;
+      if final node has more than one edge,
       `output_edge_order` must be provided.
     memory_limit: Maximum number of elements in an array during contractions.
 
@@ -189,7 +186,7 @@ def auto(net: network.TensorNetwork,
   if n == 1:
     edges = net.get_all_nondangling()
     net.contract_parallel(edges.pop())
-    final_node = net.get_final_node()   
+    final_node = net.get_final_node()
     if (len(final_node.edges) <= 1) and (output_edge_order is None):
       output_edge_order = list((net.get_all_edges() -
                                 net.get_all_nondangling()))
@@ -197,7 +194,7 @@ def auto(net: network.TensorNetwork,
       raise ValueError("if the final node has more than one dangling edge"
                        ", `output_edge_order` has to be provided")
 
-    final_node.reorder_edges(output_edge_order)    
+    final_node.reorder_edges(output_edge_order)
     return net
   if n < 5:
     return optimal(net, output_edge_order, memory_limit)
@@ -209,12 +206,12 @@ def auto(net: network.TensorNetwork,
     return branch(net, output_edge_order, nbranch=1)
   return greedy(net, output_edge_order, memory_limit)
 
+
 def custom(net: network.TensorNetwork,
            optimizer: Any,
            output_edge_order: Sequence[network_components.Edge] = None,
            memory_limit: Optional[int] = None) -> network.TensorNetwork:
-  """
-  Uses a custom path optimizer created by the user to calculate paths.
+  """Uses a custom path optimizer created by the user to calculate paths.
 
   The custom path optimizer should inherit `opt_einsum`'s `PathOptimizer`.
   For more details:
@@ -222,10 +219,10 @@ def custom(net: network.TensorNetwork,
 
   Args:
     net: a TensorNetwork object.
-    output_edge_order: An optional list of edges. 
-      Edges of the final node in `nodes_set` 
-      are reordered into `output_edge_order`; 
-      if final node has more than one edge, 
+    output_edge_order: An optional list of edges.
+      Edges of the final node in `nodes_set`
+      are reordered into `output_edge_order`;
+      if final node has more than one edge,
       output_edge_order` must be provided.
     optimizer: A custom `opt_einsum.PathOptimizer` object.
     memory_limit: Maximum number of elements in an array during contractions.

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -49,9 +49,7 @@ def base(net: network.TensorNetwork, algorithm: utils.Algorithm,
     return net
 
   # Then apply `opt_einsum`'s algorithm
-  path = utils.get_path(net, algorithm)
-
-  nodes = sorted(net.nodes_set, key = lambda n: n.signature)
+  path, nodes = utils.get_path(net, algorithm)
   for a, b in path:
     new_node = nodes[a] @ nodes[b]
     nodes.append(new_node)

--- a/tensornetwork/contractors/opt_einsum_paths/utils.py
+++ b/tensornetwork/contractors/opt_einsum_paths/utils.py
@@ -1,8 +1,8 @@
 from tensornetwork import network
-from typing import Set, Dict, List, Tuple
+from typing import Any, Dict, List, Set
 
 
-def multi_remove(elems, indices):
+def multi_remove(elems: List[Any], indices: List[int]) -> List[Any]:
   """Remove multiple indicies in a list at once."""
   return [i for j, i in enumerate(elems) if j not in indices]
 

--- a/tensornetwork/contractors/opt_einsum_paths/utils.py
+++ b/tensornetwork/contractors/opt_einsum_paths/utils.py
@@ -27,26 +27,9 @@ def multi_remove(elems: List[Any], indices: List[int]) -> List[Any]:
   return [i for j, i in enumerate(elems) if j not in indices]
 
 
-def get_input_sets(net: network.TensorNetwork
-                   ) -> Tuple[Union[List[Set[network_components.Edge]],
-                                    List[network_components.Node]]]:
-  sorted_nodes = sorted(net.nodes_set, key = lambda n: n.signature)
-  input_sets = [set(node.edges) for node in sorted_nodes]
-  return input_sets, sorted_nodes
-
-
-def get_output_set(net: network.TensorNetwork) -> Set[network_components.Edge]:
-  dangling_edges = net.get_all_edges() - net.get_all_nondangling()
-  return set(dangling_edges)
-
-
-def get_size_dict(net: network.TensorNetwork
-                  ) -> Dict[network_components.Edge, int]:
-  return {edge: edge.dimension for edge in net.get_all_edges()}
-
-
 def get_path(net: network.TensorNetwork, algorithm: Algorithm
-             ) -> Tuple[Union[List[Tuple[int]], List[network_components.Node]]]:
+             ) -> Tuple[Union[List[Tuple[int]],
+                        List[network_components.BaseNode]]]:
   """Calculates the contraction paths using `opt_einsum` methods.
 
   Args:
@@ -57,7 +40,10 @@ def get_path(net: network.TensorNetwork, algorithm: Algorithm
     The optimal contraction path as returned by `opt_einsum`.
     A list of nodes sorted compatibly with their indices in the path.
   """
-  input_sets, sorted_nodes = get_input_sets(net)
-  output_set = get_output_set(net)
-  size_dict = get_size_dict(net)
+  sorted_nodes = sorted(net.nodes_set, key = lambda n: n.signature)
+
+  input_sets = [set(node.edges) for node in sorted_nodes]
+  output_set = net.get_all_edges() - net.get_all_nondangling()
+  size_dict = {edge: edge.dimension for edge in net.get_all_edges()}
+
   return algorithm(input_sets, output_set, size_dict), sorted_nodes

--- a/tensornetwork/contractors/opt_einsum_paths/utils.py
+++ b/tensornetwork/contractors/opt_einsum_paths/utils.py
@@ -1,7 +1,23 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper methods for `path_contractors`."""
+
 from tensornetwork import network
+from tensornetwork import network_components
 from typing import Any, Callable, Dict, List, Set, Tuple
 
-
+# `opt_einsum` algorithm method typing
 Algorithm = Callable[[List[Set[int]], Set[int], Dict[int, int]],
                      List[Tuple[int]]]
 
@@ -11,24 +27,35 @@ def multi_remove(elems: List[Any], indices: List[int]) -> List[Any]:
   return [i for j, i in enumerate(elems) if j not in indices]
 
 
-def get_input_sets(net: network.TensorNetwork) -> List[Set[int]]:
+def get_input_sets(net: network.TensorNetwork
+                   ) -> List[Set[network_components.Edge]]:
   input_sets = []
-  for node in sorted(net.nodes_set):
+  for node in sorted(net.nodes_set, key = lambda n: n.signature):
     input_sets.append(set(node.edges))
   return input_sets
 
 
-def get_output_set(net: network.TensorNetwork) -> Set[int]:
+def get_output_set(net: network.TensorNetwork) -> Set[network_components.Edge]:
   dangling_edges = net.get_all_edges() - net.get_all_nondangling()
   return set(dangling_edges)
 
 
-def get_size_dict(net: network.TensorNetwork) -> Dict[int, int]:
+def get_size_dict(net: network.TensorNetwork
+                  ) -> Dict[network_components.Edge, int]:
   return {edge: edge.dimension for edge in net.get_all_edges()}
 
 
 def get_path(net: network.TensorNetwork, algorithm: Algorithm
              ) -> List[Tuple[int]]:
+  """Calculates the contraction paths using `opt_einsum` methods.
+
+  Args:
+    net: TensorNetwork object to contract.
+    algorithm: `opt_einsum` method to use for calculating the contraction path.
+
+  Returns:
+    The optimal contraction path as returned by `opt_einsum`.
+  """
   input_sets = get_input_sets(net)
   output_set = get_output_set(net)
   size_dict = get_size_dict(net)

--- a/tensornetwork/contractors/opt_einsum_paths/utils.py
+++ b/tensornetwork/contractors/opt_einsum_paths/utils.py
@@ -1,5 +1,9 @@
 from tensornetwork import network
-from typing import Any, Dict, List, Set
+from typing import Any, Callable, Dict, List, Set, Tuple
+
+
+Algorithm = Callable[[List[Set[int]], Set[int], Dict[int, int]],
+                     List[Tuple[int]]]
 
 
 def multi_remove(elems: List[Any], indices: List[int]) -> List[Any]:
@@ -21,3 +25,11 @@ def get_output_set(net: network.TensorNetwork) -> Set[int]:
 
 def get_size_dict(net: network.TensorNetwork) -> Dict[int, int]:
   return {edge: edge.dimension for edge in net.get_all_edges()}
+
+
+def get_path(net: network.TensorNetwork, algorithm: Algorithm
+             ) -> List[Tuple[int]]:
+  input_sets = get_input_sets(net)
+  output_set = get_output_set(net)
+  size_dict = get_size_dict(net)
+  return algorithm(input_sets, output_set, size_dict)

--- a/tensornetwork/contractors/opt_einsum_paths/utils.py
+++ b/tensornetwork/contractors/opt_einsum_paths/utils.py
@@ -14,7 +14,6 @@
 """Helper methods for `path_contractors`."""
 
 from tensornetwork import network
-from tensornetwork import network_components
 from typing import Any, Callable, Dict, List, Set, Tuple
 
 # `opt_einsum` algorithm method typing
@@ -28,7 +27,7 @@ def multi_remove(elems: List[Any], indices: List[int]) -> List[Any]:
 
 
 def get_path(net: network.TensorNetwork, algorithm: Algorithm
-             ) -> Tuple[List[Tuple[int]], List[network_components.BaseNode]]:
+             ) -> List[Tuple[int]]:
   """Calculates the contraction paths using `opt_einsum` methods.
 
   Args:
@@ -37,7 +36,6 @@ def get_path(net: network.TensorNetwork, algorithm: Algorithm
 
   Returns:
     The optimal contraction path as returned by `opt_einsum`.
-    A list of nodes sorted compatibly with their indices in the path.
   """
   sorted_nodes = sorted(net.nodes_set, key=lambda n: n.signature)
 
@@ -45,4 +43,4 @@ def get_path(net: network.TensorNetwork, algorithm: Algorithm
   output_set = net.get_all_edges() - net.get_all_nondangling()
   size_dict = {edge: edge.dimension for edge in net.get_all_edges()}
 
-  return algorithm(input_sets, output_set, size_dict), sorted_nodes
+  return algorithm(input_sets, output_set, size_dict)

--- a/tensornetwork/contractors/opt_einsum_paths/utils.py
+++ b/tensornetwork/contractors/opt_einsum_paths/utils.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, List, Set, Tuple
 
 # `opt_einsum` algorithm method typing
 Algorithm = Callable[[List[Set[int]], Set[int], Dict[int, int]],
-                     List[Tuple[int]]]
+                     List[Tuple[int, int]]]
 
 
 def multi_remove(elems: List[Any], indices: List[int]) -> List[Any]:

--- a/tensornetwork/contractors/opt_einsum_paths/utils.py
+++ b/tensornetwork/contractors/opt_einsum_paths/utils.py
@@ -14,6 +14,7 @@
 """Helper methods for `path_contractors`."""
 
 from tensornetwork import network
+from tensornetwork import network_components
 from typing import Any, Callable, Dict, List, Set, Tuple
 
 # `opt_einsum` algorithm method typing
@@ -27,7 +28,8 @@ def multi_remove(elems: List[Any], indices: List[int]) -> List[Any]:
 
 
 def get_path(net: network.TensorNetwork, algorithm: Algorithm
-             ) -> List[Tuple[int]]:
+             ) -> Tuple[List[Tuple[int, int]],
+                        List[network_components.BaseNode]]:
   """Calculates the contraction paths using `opt_einsum` methods.
 
   Args:
@@ -43,4 +45,4 @@ def get_path(net: network.TensorNetwork, algorithm: Algorithm
   output_set = net.get_all_edges() - net.get_all_nondangling()
   size_dict = {edge: edge.dimension for edge in net.get_all_edges()}
 
-  return algorithm(input_sets, output_set, size_dict)
+  return algorithm(input_sets, output_set, size_dict), sorted_nodes

--- a/tensornetwork/contractors/opt_einsum_paths/utils.py
+++ b/tensornetwork/contractors/opt_einsum_paths/utils.py
@@ -15,7 +15,7 @@
 
 from tensornetwork import network
 from tensornetwork import network_components
-from typing import Any, Callable, Dict, List, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Set, Tuple
 
 # `opt_einsum` algorithm method typing
 Algorithm = Callable[[List[Set[int]], Set[int], Dict[int, int]],
@@ -28,8 +28,7 @@ def multi_remove(elems: List[Any], indices: List[int]) -> List[Any]:
 
 
 def get_path(net: network.TensorNetwork, algorithm: Algorithm
-             ) -> Tuple[Union[List[Tuple[int]],
-                        List[network_components.BaseNode]]]:
+             ) -> Tuple[List[Tuple[int]], List[network_components.BaseNode]]:
   """Calculates the contraction paths using `opt_einsum` methods.
 
   Args:
@@ -40,7 +39,7 @@ def get_path(net: network.TensorNetwork, algorithm: Algorithm
     The optimal contraction path as returned by `opt_einsum`.
     A list of nodes sorted compatibly with their indices in the path.
   """
-  sorted_nodes = sorted(net.nodes_set, key = lambda n: n.signature)
+  sorted_nodes = sorted(net.nodes_set, key=lambda n: n.signature)
 
   input_sets = [set(node.edges) for node in sorted_nodes]
   output_set = net.get_all_edges() - net.get_all_nondangling()


### PR DESCRIPTION
Applied the changes discussed in #228 and added tests that explicitly test the calculated contraction paths, not the contraction result.

Right now I am using some toy tensor network examples and check if paths agree with the optimal contraction calculated by hand. The idea was to also use the examples from `opt_einsum` tests ([the `path_edge_tests` list](https://github.com/dgasmith/opt_einsum/blob/4c123e0db151cf81a58fcfc1a3314be3802095ea/opt_einsum/tests/test_paths.py#L30)). The problem is that all examples in this list have repeated indices which is not supported in our case. We can actually support this with our `CopyNode`, but I think this would require to modify our `opt_einsum` contractors (currently `CopyNode`s are treated as normal nodes). I've started looking into this but perhaps would be better to keep it as a separate PR.

Also, since yesterday `opt_einsum` has a [dynamic programming contractor](https://github.com/dgasmith/opt_einsum/pull/102) we should add, but it is not on their `pip` release yet.