### PR TITLE
fix bug in the tensorflow backend

### DIFF
--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -70,6 +70,7 @@ def svd_decomposition(
 
   return u, s, vh, s_rest
 
+
 def qr_decomposition(
     np,  # TODO: Typing
     tensor: Tensor,
@@ -88,6 +89,7 @@ def qr_decomposition(
   r = np.reshape(r, [center_dim] + list(right_dims))
   return q, r
 
+
 def rq_decomposition(
     np,  # TODO: Typing
     tensor: Tensor,
@@ -101,7 +103,8 @@ def rq_decomposition(
   right_dims = tensor.shape[split_axis:]
   tensor = np.reshape(tensor, [numpy.prod(left_dims), numpy.prod(right_dims)])
   q, r = np.linalg.qr(np.conj(np.transpose(tensor)))
-  r, q = np.conj(np.transpose(r)), np.conj(np.transpose(q))#M=r*q at this point
+  r, q = np.conj(np.transpose(r)), np.conj(
+      np.transpose(q))  #M=r*q at this point
   center_dim = r.shape[1]
   r = np.reshape(r, list(left_dims) + [center_dim])
   q = np.reshape(q, [center_dim] + list(right_dims))

--- a/tensornetwork/backends/pytorch/decompositions.py
+++ b/tensornetwork/backends/pytorch/decompositions.py
@@ -115,10 +115,12 @@ def svd_decomposition(torch: Any,
 
   return u, s, vh, s_rest
 
-def qr_decomposition(torch: Any,
-                     tensor: Tensor,
-                     split_axis: int,
-                     ) -> Tuple[Tensor, Tensor]:
+
+def qr_decomposition(
+    torch: Any,
+    tensor: Tensor,
+    split_axis: int,
+) -> Tuple[Tensor, Tensor]:
   """Computes the QR decomposition of a tensor.
 
   The QR decomposition is performed by treating the tensor as a matrix, 
@@ -153,15 +155,16 @@ def qr_decomposition(torch: Any,
   tensor = torch.reshape(tensor, (np.prod(left_dims), np.prod(right_dims)))
   q, r = torch.qr(tensor)
   center_dim = q.shape[1]
-  q = torch.reshape(q, list(left_dims) + [center_dim])
-  r = torch.reshape(r, [center_dim] + list(right_dims))
+  q = torch.reshape(q, left_dims + [center_dim])
+  r = torch.reshape(r, [center_dim] + right_dims)
   return q, r
 
 
-def rq_decomposition(torch: Any,
-                     tensor: Tensor,
-                     split_axis: int,
-                     ) -> Tuple[Tensor, Tensor]:
+def rq_decomposition(
+    torch: Any,
+    tensor: Tensor,
+    split_axis: int,
+) -> Tuple[Tensor, Tensor]:
   """Computes the RQ decomposition of a tensor.
 
   The RQ decomposition is performed by treating the tensor as a matrix, 
@@ -193,10 +196,11 @@ def rq_decomposition(torch: Any,
   left_dims = tensor.shape[:split_axis]
   right_dims = tensor.shape[split_axis:]
   tensor = torch.reshape(tensor, [np.prod(left_dims), np.prod(right_dims)])
-  #torch has currently no support for complex dtypes  
-  q, r = torch.qr(torch.transpose(tensor, 0, 1)) 
-  r, q = torch.transpose(r, 0, 1), torch.transpose(q, 0, 1)#M=r*q at this point
+  #torch has currently no support for complex dtypes
+  q, r = torch.qr(torch.transpose(tensor, 0, 1))
+  r, q = torch.transpose(r, 0, 1), torch.transpose(q, 0,
+                                                   1)  #M=r*q at this point
   center_dim = r.shape[1]
-  r = torch.reshape(r, list(left_dims) + [center_dim])
-  q = torch.reshape(q, [center_dim] + list(right_dims))
+  r = torch.reshape(r, left_dims + [center_dim])
+  q = torch.reshape(q, [center_dim] + right_dims)
   return r, q

--- a/tensornetwork/backends/pytorch/decompositions.py
+++ b/tensornetwork/backends/pytorch/decompositions.py
@@ -155,8 +155,8 @@ def qr_decomposition(
   tensor = torch.reshape(tensor, (np.prod(left_dims), np.prod(right_dims)))
   q, r = torch.qr(tensor)
   center_dim = q.shape[1]
-  q = torch.reshape(q, left_dims + [center_dim])
-  r = torch.reshape(r, [center_dim] + right_dims)
+  q = torch.reshape(q, list(left_dims) + [center_dim])
+  r = torch.reshape(r, [center_dim] + list(right_dims))
   return q, r
 
 
@@ -201,6 +201,6 @@ def rq_decomposition(
   r, q = torch.transpose(r, 0, 1), torch.transpose(q, 0,
                                                    1)  #M=r*q at this point
   center_dim = r.shape[1]
-  r = torch.reshape(r, left_dims + [center_dim])
-  q = torch.reshape(q, [center_dim] + right_dims)
+  r = torch.reshape(r, list(left_dims) + [center_dim])
+  q = torch.reshape(q, [center_dim] + list(right_dims))
   return r, q

--- a/tensornetwork/backends/tensorflow/decompositions.py
+++ b/tensornetwork/backends/tensorflow/decompositions.py
@@ -119,11 +119,11 @@ def svd_decomposition(tf: Any,
   return u, s, vh, s_rest
 
 
-
-def qr_decomposition(tf: Any,
-                     tensor: Tensor,
-                     split_axis: int,
-                     ) -> Tuple[Tensor, Tensor]:
+def qr_decomposition(
+    tf: Any,
+    tensor: Tensor,
+    split_axis: int,
+) -> Tuple[Tensor, Tensor]:
   """Computes the QR decomposition of a tensor.
 
   The QR decomposition is performed by treating the tensor as a matrix, 
@@ -159,15 +159,16 @@ def qr_decomposition(tf: Any,
                        tf.reduce_prod(right_dims)])
   q, r = tf.linalg.qr(tensor)
   center_dim = tf.shape(q)[1]
-  q = tf.reshape(q, list(left_dims) + [center_dim])
-  r = tf.reshape(r, [center_dim] + list(right_dims))
+  q = tf.reshape(q, tf.concat([left_dims, [center_dim]], axis=-1))
+  r = tf.reshape(r, tf.concat([[center_dim], right_dims], axis=-1))
   return q, r
 
 
-def rq_decomposition(tf: Any,
-                     tensor: Tensor,
-                     split_axis: int,
-                     ) -> Tuple[Tensor, Tensor]:
+def rq_decomposition(
+    tf: Any,
+    tensor: Tensor,
+    split_axis: int,
+) -> Tuple[Tensor, Tensor]:
   """Computes the RQ decomposition of a tensor.
 
   The QR decomposition is performed by treating the tensor as a matrix, 
@@ -202,8 +203,9 @@ def rq_decomposition(tf: Any,
                       [tf.reduce_prod(left_dims),
                        tf.reduce_prod(right_dims)])
   q, r = tf.linalg.qr(tf.conj(tf.transpose(tensor)))
-  r, q = tf.conj(tf.transpose(r)), tf.conj(tf.transpose(q))#M=r*q at this point
+  r, q = tf.conj(tf.transpose(r)), tf.conj(
+      tf.transpose(q))  #M=r*q at this point
   center_dim = tf.shape(r)[1]
-  r = tf.reshape(r, list(left_dims) + [center_dim])
-  q = tf.reshape(q, [center_dim] + list(right_dims))
+  r = tf.reshape(r, tf.concat([left_dims, [center_dim]], axis=-1))
+  q = tf.reshape(q, tf.concat([[center_dim], right_dims], axis=-1))
   return r, q

--- a/tensornetwork/backends/tensorflow/decompositions_test.py
+++ b/tensornetwork/backends/tensorflow/decompositions_test.py
@@ -53,6 +53,18 @@ class DecompositionsTest(tf.test.TestCase):
     q, r = decompositions.qr_decomposition(tf, random_matrix, 1)
     self.assertAllClose(tf.tensordot(q, r, ([1], [0])), random_matrix)
 
+  def test_rq_decomposition_defun(self):
+    random_matrix = np.random.rand(10, 10)
+    rq_decomposition = tf.function(decompositions.rq_decomposition)
+    r, q = rq_decomposition(tf, random_matrix, 1)
+    self.assertAllClose(tf.tensordot(r, q, ([1], [0])), random_matrix)
+
+  def test_qr_decomposition_defun(self):
+    random_matrix = np.random.rand(10, 10)
+    qr_decomposition = tf.function(decompositions.qr_decomposition)
+    q, r = qr_decomposition(tf, random_matrix, 1)
+    self.assertAllClose(tf.tensordot(q, r, ([1], [0])), random_matrix)
+
   def test_max_singular_values(self):
     random_matrix = np.random.rand(10, 10)
     unitary1, _, unitary2 = np.linalg.svd(random_matrix)
@@ -60,6 +72,19 @@ class DecompositionsTest(tf.test.TestCase):
     val = unitary1.dot(np.diag(singular_values).dot(unitary2.T))
     u, s, vh, trun = decompositions.svd_decomposition(
         tf, val, 1, max_singular_values=7)
+    self.assertEqual(u.shape, (10, 7))
+    self.assertEqual(s.shape, (7,))
+    self.assertAllClose(s, np.arange(9, 2, -1))
+    self.assertEqual(vh.shape, (7, 10))
+    self.assertAllClose(trun, np.arange(2, -1, -1))
+
+  def test_max_singular_values_defun(self):
+    random_matrix = np.random.rand(10, 10)
+    unitary1, _, unitary2 = np.linalg.svd(random_matrix)
+    singular_values = np.array(range(10))
+    val = unitary1.dot(np.diag(singular_values).dot(unitary2.T))
+    svd_decomposition = tf.function(decompositions.svd_decomposition)
+    u, s, vh, trun = svd_decomposition(tf, val, 1, max_singular_values=7)
     self.assertEqual(u.shape, (10, 7))
     self.assertEqual(s.shape, (7,))
     self.assertAllClose(s, np.arange(9, 2, -1))


### PR DESCRIPTION
the tensorflow backend crashes for QR and RQ decomps in graph mode.
This is because there is a list addition in `qr_decomposition` and `rq_decomposition`. 
I changed it to `tf.concat` to fix this problem