### PR TITLE
Fix tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,9 +16,33 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import pytest
+import jax
+import tensornetwork
+import tensorflow as tf
 
 
 @pytest.fixture(name="backend", params=["numpy", "tensorflow",
                                         "jax", "pytorch"])
 def backend_fixure(request):
   return request.param
+
+
+@pytest.fixture(autouse=True)
+def reset_default_backend():
+  tensornetwork.set_default_backend("numpy")
+  yield
+  tensornetwork.set_default_backend("numpy")
+
+
+@pytest.fixture(autouse=True)
+def enable_jax_64():
+  jax.config.update("jax_enable_x64", True)
+  yield
+  jax.config.update("jax_enable_x64", True)
+
+
+@pytest.fixture(autouse=True)
+def tf_enable_v2_behaviour():
+  tf.compat.v1.enable_v2_behavior()
+  yield
+  tf.compat.v1.enable_v2_behavior()

--- a/experiments/MERA/binary_mera_test.py
+++ b/experiments/MERA/binary_mera_test.py
@@ -22,8 +22,15 @@ import experiments.MERA.binary_mera as bm
 import experiments.MERA.misc_mera as misc_mera
 import pytest
 import copy
-tn.set_default_backend("tensorflow")
 tf.enable_v2_behavior()
+
+
+@pytest.fixture(autouse=True)
+def backend_tensorflow():
+    tn.set_default_backend("tensorflow")
+    yield
+    tn.set_default_backend("numpy")
+
 
 @pytest.mark.parametrize("chi", [4, 6])
 @pytest.mark.parametrize("dtype", [tf.float64, tf.complex128])

--- a/experiments/MERA/binary_mera_test.py
+++ b/experiments/MERA/binary_mera_test.py
@@ -18,11 +18,8 @@ import tensorflow as tf
 import numpy as np
 import tensornetwork as tn
 import experiments.MERA.binary_mera_lib as bml
-import experiments.MERA.binary_mera as bm
 import experiments.MERA.misc_mera as misc_mera
 import pytest
-import copy
-tf.enable_v2_behavior()
 
 
 @pytest.fixture(autouse=True)

--- a/experiments/MPS/dmrg_test.py
+++ b/experiments/MPS/dmrg_test.py
@@ -15,15 +15,11 @@
 unittests
 """
 import tensorflow as tf
-import tensornetwork as tn
-import experiments.MPS.misc_mps as misc_mps
 import experiments.MPS.matrixproductstates as MPS
 import experiments.MPS.DMRG as DMRG
 import experiments.MPS.matrixproductoperators as MPO
 import pytest
 import numpy as np
-
-tf.enable_v2_behavior()
 
 
 @pytest.mark.parametrize("dtype", [tf.float64, tf.complex128])

--- a/experiments/MPS/mps_test.py
+++ b/experiments/MPS/mps_test.py
@@ -15,15 +15,10 @@
 unittests
 """
 import tensorflow as tf
-import tensornetwork as tn
 import experiments.MPS.misc_mps as misc_mps
 import experiments.MPS.matrixproductstates as MPS
-import experiments.MPS.DMRG as DMRG
-import experiments.MPS.matrixproductoperators as MPO
 import pytest
 import numpy as np
-
-tf.enable_v2_behavior()
 
 
 @pytest.mark.parametrize("direction", ['l', 'r'])

--- a/experiments/MPS_classifier/MPSMNIST_test.py
+++ b/experiments/MPS_classifier/MPSMNIST_test.py
@@ -1,12 +1,8 @@
-import sys
-from sys import stdout
 import numpy as np
 import experiments.MPS.misc_mps as misc_mps
-import itertools
 import experiments.MPS_classifier.MPSMNIST as mm
 import pytest
 import tensorflow as tf
-tf.enable_v2_behavior()
 
 
 def test_predict():

--- a/experiments/MPS_classifier/batchtensornetwork_test.py
+++ b/experiments/MPS_classifier/batchtensornetwork_test.py
@@ -18,10 +18,7 @@ from __future__ import print_function
 
 import pytest
 import numpy as np
-import tensorflow as tf
 from experiments.MPS_classifier import batchtensornetwork
-
-tf.enable_v2_behavior()
 
 
 @pytest.fixture(

--- a/experiments/MPS_classifier/classifier_test.py
+++ b/experiments/MPS_classifier/classifier_test.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 from experiments.MPS_classifier import classifier
-tf.enable_v2_behavior()
 
 
 def test_random_initializer_shapes():

--- a/experiments/tree_tensor_network/ttn_test.py
+++ b/experiments/tree_tensor_network/ttn_test.py
@@ -17,13 +17,8 @@ Tree tensor network unit tests.
 import pytest
 import numpy as np
 import tensorflow as tf
-from jax.config import config
-config.update("jax_enable_x64", True)
-import tensornetwork as tn
 import examples.wavefunctions.wavefunctions as wf
 import experiments.tree_tensor_network as ttn
-
-tf.enable_v2_behavior()
 
 
 def test_opt(backend):

--- a/tensornetwork/__init__.py
+++ b/tensornetwork/__init__.py
@@ -12,4 +12,4 @@ from tensornetwork.utils import load
 
 def set_default_backend(backend: Text, dtype: Optional[Type] = None) -> None:
   config.default_backend = backend
-  config.default_dype = dtype
+  config.default_dtype = dtype

--- a/tensornetwork/backends/backend_test.py
+++ b/tensornetwork/backends/backend_test.py
@@ -2,16 +2,21 @@
 import builtins
 import sys
 import pytest
+import numpy as np
+
+
+def clean_tensornetwork_modules():
+  for mod in list(sys.modules.keys()):
+    if mod.startswith('tensornetwork'):
+      sys.modules.pop(mod, None)
 
 
 @pytest.fixture(autouse=True)
 def clean_backend_import():
   #never do this outside testing
-  sys.modules.pop('tensornetwork.backends.pytorch.pytorch_backend', None)
-  sys.modules.pop('tensornetwork.backends.jax.jax_backend', None)
-  sys.modules.pop('tensornetwork.backends.tensorflow.tensorflow_backend', None)
+  clean_tensornetwork_modules()
   yield # use as teardown
-  sys.modules.pop('tensornetwork', None)
+  clean_tensornetwork_modules()
 
 
 @pytest.fixture
@@ -31,6 +36,7 @@ def test_backend_pytorch_missing_cannot_initialize_backend():
     from tensornetwork.backends.pytorch.pytorch_backend import PyTorchBackend
     PyTorchBackend()
 
+
 @pytest.mark.usefixtures('no_backend_dependency')
 def test_backend_tensorflow_missing_cannot_initialize_backend():
   with pytest.raises(ImportError):
@@ -38,36 +44,52 @@ def test_backend_tensorflow_missing_cannot_initialize_backend():
       import TensorFlowBackend
     TensorFlowBackend()
 
+
 @pytest.mark.usefixtures('no_backend_dependency')
 def test_backend_jax_missing_cannot_initialize_backend():
   with pytest.raises(ImportError):
     from tensornetwork.backends.jax.jax_backend import JaxBackend
     JaxBackend()
 
+
 @pytest.mark.usefixtures('no_backend_dependency')
-def test_config_pytorch_missing_can_import_config():
+def test_config_backend_missing_can_import_config():
   import tensornetwork.config
-  with pytest.raises(ImportError):
-    import torch
-
-
-@pytest.mark.usefixtures('no_backend_dependency')
-def test_config_tensorflow_missing_can_import_config():
-  import tensornetwork.config
-  with pytest.raises(ImportError):
-    import tensorflow as tf
-
-
-@pytest.mark.usefixtures('no_backend_dependency')
-def test_import_tensornetwork_without_backends():
   with pytest.raises(ImportError):
     import torch
   with pytest.raises(ImportError):
     import tensorflow as tf
   with pytest.raises(ImportError):
     import jax
+
+
+@pytest.mark.usefixtures('no_backend_dependency')
+def test_import_tensornetwork_without_backends():
   import tensornetwork
   import tensornetwork.backends.pytorch.pytorch_backend
   import tensornetwork.backends.tensorflow.tensorflow_backend
   import tensornetwork.backends.jax.jax_backend
   import tensornetwork.backends.numpy.numpy_backend
+  with pytest.raises(ImportError):
+    import torch
+  with pytest.raises(ImportError):
+    import tensorflow as tf
+  with pytest.raises(ImportError):
+    import jax
+
+
+@pytest.mark.usefixtures('no_backend_dependency')
+def test_basic_numpy_network_without_backends():
+  import tensornetwork
+  net = tensornetwork.TensorNetwork(backend="numpy")
+  a = net.add_node(np.ones((10,)))
+  b = net.add_node(np.ones((10,)))
+  edge = net.connect(a[0], b[0])
+  final_node = net.contract(edge)
+  assert final_node.tensor == np.array(10.)
+  with pytest.raises(ImportError):
+    import torch
+  with pytest.raises(ImportError):
+    import tensorflow as tf
+  with pytest.raises(ImportError):
+    import jax

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -10,7 +10,6 @@ from tensornetwork.backends.jax import jax_backend
 
 np_randn_dtypes = [np.float32, np.float16, np.float64]
 np_dtypes = np_randn_dtypes + [np.complex64, np.complex128]
-jax.config.update("jax_enable_x64", True)
 
 
 def test_tensordot():

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -207,8 +207,6 @@ def test_randn_dtype(dtype):
 def test_eye_dtype_2(dtype):
   backend = jax_backend.JaxBackend(dtype=dtype)
   a = backend.eye(N=4, M=4)
-  print('testing')
-  print(a.dtype)
   assert a.dtype == dtype
 
 

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -7,10 +7,10 @@ import numpy as np
 import jax
 import pytest
 from tensornetwork.backends.jax import jax_backend
-import tensornetwork.config as config_file
 
 np_randn_dtypes = [np.float32, np.float16, np.float64]
 np_dtypes = np_randn_dtypes + [np.complex64, np.complex128]
+jax.config.update("jax_enable_x64", True)
 
 
 def test_tensordot():
@@ -207,6 +207,8 @@ def test_randn_dtype(dtype):
 def test_eye_dtype_2(dtype):
   backend = jax_backend.JaxBackend(dtype=dtype)
   a = backend.eye(N=4, M=4)
+  print('testing')
+  print(a.dtype)
   assert a.dtype == dtype
 
 

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 import numpy as np
 import pytest
 from tensornetwork.backends.numpy import numpy_backend
-import tensornetwork.config as config_file
+
 
 np_randn_dtypes = [np.float32, np.float16, np.float64]
 np_dtypes = np_randn_dtypes + [np.complex64, np.complex128]

--- a/tensornetwork/backends/pytorch/pytorch_backend_test.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend_test.py
@@ -6,7 +6,7 @@ import numpy as np
 from tensornetwork.backends.pytorch import pytorch_backend
 import torch
 import pytest
-import tensornetwork.config as config_file
+
 
 torch_dtypes = [torch.float32, torch.float64, torch.int32]
 torch_eye_dtypes = [torch.float32, torch.float64, torch.int32, torch.int64]

--- a/tensornetwork/backends/tensorflow/tensordot2_test.py
+++ b/tensornetwork/backends/tensorflow/tensordot2_test.py
@@ -37,7 +37,7 @@ import tensorflow as tf
 from tensornetwork.backends.tensorflow import tensordot2
 import pytest
 
-tf.compat.v1.enable_v2_behavior()
+
 _MAXDIM = 5
 
 

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -5,9 +5,8 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 import pytest
-import tensornetwork.config as config_file
 from tensornetwork.backends.tensorflow import tensorflow_backend
-tf.compat.v1.enable_v2_behavior()
+
 
 tf_randn_dtypes = [tf.float32, tf.float16, tf.float64]
 tf_dtypes = tf_randn_dtypes + [tf.complex128, tf.complex64]

--- a/tensornetwork/backends/tensorflow/tensorflow_tensornetwork_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_tensornetwork_test.py
@@ -4,7 +4,6 @@ from __future__ import division
 from __future__ import print_function
 import numpy as np
 import tensorflow as tf
-tf.compat.v1.enable_v2_behavior()
 import tensornetwork
 
 

--- a/tensornetwork/contractors/cost_calculators_test.py
+++ b/tensornetwork/contractors/cost_calculators_test.py
@@ -18,7 +18,6 @@ from __future__ import division
 from __future__ import print_function
 import numpy as np
 import pytest
-from typing import List, Optional, Tuple
 from tensornetwork.contractors import cost_calculators
 from tensornetwork import network
 

--- a/tensornetwork/contractors/greedy_contractor_test.py
+++ b/tensornetwork/contractors/greedy_contractor_test.py
@@ -17,8 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import numpy as np
-import pytest
-from typing import List, Optional, Tuple
 from tensornetwork.contractors import greedy_contractor
 from tensornetwork import network
 

--- a/tensornetwork/contractors/naive_contractor_test.py
+++ b/tensornetwork/contractors/naive_contractor_test.py
@@ -22,8 +22,6 @@ import pytest
 
 from tensornetwork import network
 from tensornetwork.contractors import naive_contractor
-import tensorflow as tf
-tf.enable_v2_behavior()
 naive = naive_contractor.naive
 
 

--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors_test.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors_test.py
@@ -16,8 +16,6 @@ import numpy as np
 import pytest
 import tensornetwork
 from tensornetwork.contractors.opt_einsum_paths import path_contractors
-import tensorflow as tf
-tf.enable_v2_behavior()
 
 
 @pytest.fixture(name="path_algorithm",

--- a/tensornetwork/contractors/stochastic_contractor_test.py
+++ b/tensornetwork/contractors/stochastic_contractor_test.py
@@ -21,7 +21,6 @@ import numpy as np
 import tensorflow as tf
 from tensornetwork import network
 from tensornetwork.contractors import stochastic_contractor
-tf.compat.v1.enable_v2_behavior()
 
 
 class StochasticTest(tf.test.TestCase):

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -30,10 +30,12 @@ def test_sanity_check(backend):
 def test_order_spec(backend):
   a = np.ones((2, 2))
 
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2], backend=backend)
+  result = ncon_interface.ncon(
+      [a, a], [(-1, 1), (1, -2)], out_order=[-1, -2], backend=backend)
   np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1], backend=backend)
+  result = ncon_interface.ncon(
+      [a, a], [(-1, 1), (1, -2)], con_order=[1], backend=backend)
   np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
   result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)],
@@ -71,11 +73,11 @@ def test_invalid_network(backend):
 def test_invalid_order(backend):
   a = np.ones((2, 2))
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3], 
-        backend=backend)
+    ncon_interface.ncon(
+        [a, a], [(1, 2), (2, 1)], con_order=[2, 3], backend=backend)
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1], 
-        backend=backend)
+    ncon_interface.ncon(
+        [a, a], [(1, 2), (2, 1)], out_order=[-1], backend=backend)
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1'],
@@ -93,8 +95,8 @@ def test_invalid_order(backend):
 def test_out_of_order_contraction(backend):
   a = np.ones((2, 2, 2))
   with pytest.warns(UserWarning, match='Suboptimal ordering'):
-    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)],
-        backend=backend)
+    ncon_interface.ncon(
+        [a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)], backend=backend)
 
 
 def test_output_order(backend):
@@ -110,8 +112,8 @@ def test_outer_product(backend):
   b = np.array([1, 2])
   res = ncon_interface.ncon([a, b], [(-1,), (-2,)], backend=backend)
   np.testing.assert_allclose(res, np.kron(a, b).reshape((3, 2)))
-  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)],
-      backend=backend)
+  res = ncon_interface.ncon(
+      [a, a, a, a], [(1,), (1,), (2,), (2,)], backend=backend)
   np.testing.assert_allclose(res, 196)
 
 
@@ -124,15 +126,15 @@ def test_trace(backend):
 def test_small_matmul(backend):
   a = np.random.randn(2, 2)
   b = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)],
-      backend=backend)
+  res = ncon_interface.ncon(
+      [a, b], [(1, -1), (1, -2)], backend=backend)
   np.testing.assert_allclose(res, a.transpose() @ b)
 
 
 def test_contraction(backend):
   a = np.random.randn(2, 2, 2)
-  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)],
-      backend=backend)
+  res = ncon_interface.ncon(
+      [a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)], backend=backend)
   res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
   res_np = res_np.reshape((2, 2, 2))
   np.testing.assert_allclose(res, res_np)

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -23,267 +23,121 @@ from tensornetwork import ncon_interface
 from tensornetwork.contractors.naive_contractor import naive
 
 
-def test_sanity_check_numpy_backend():
-  result = ncon_interface.ncon([np.ones(
-      (2, 2)), np.ones((2, 2))], [(-1, 1), (1, -2)], backend='numpy')
-  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
+def test_sanity_check():
+  result = ncon_interface.ncon([tf.ones(
+      (2, 2)), tf.ones((2, 2))], [(-1, 1), (1, -2)])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
 
 
-def test_order_spec_numpy_backend():
-  a = np.ones((2, 2))
+def test_order_spec():
+  a = tf.ones((2, 2))
 
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2],
-                               backend='numpy')
-  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
 
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1],
-                               backend='numpy')
-  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
 
   result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)],
                                con_order=[1],
-                               out_order=[-1, -2],
-                               backend='numpy')
-  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
+                               out_order=[-1, -2])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
 
 
-def test_order_spec_noninteger_numpy_backend():
-  a = np.ones((2, 2))
+def test_order_spec_noninteger():
+  a = tf.ones((2, 2))
   result = ncon_interface.ncon([a, a], [('o1', 'i'), ('i', 'o2')],
                                con_order=['i'],
-                               out_order=['o1', 'o2'],
-                               backend='numpy')
-  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
+                               out_order=['o1', 'o2'])
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
 
 
-def test_invalid_network_numpy_backend():
-  a = np.ones((2, 2))
+def test_invalid_network():
+  a = tf.ones((2, 2))
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)], backend='numpy')
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)])
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 2)], backend='numpy')
+    ncon_interface.ncon([a, a], [(1, 2), (2, 2)])
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (3, 1)], backend='numpy')
+    ncon_interface.ncon([a, a], [(1, 2), (3, 1)])
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)], backend='numpy')
+    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)])
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 't')], backend='numpy')
+    ncon_interface.ncon([a, a], [(1, 2), (2, 't')])
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(0, 1), (1, 0)], backend='numpy')
+    ncon_interface.ncon([a, a], [(0, 1), (1, 0)])
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1,), (1, 2)], backend='numpy')
+    ncon_interface.ncon([a, a], [(1,), (1, 2)])
 
 
-def test_invalid_order_numpy_backend():
-  a = np.ones((2, 2))
+def test_invalid_order():
+  a = tf.ones((2, 2))
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3],
-                        backend='numpy')
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3])
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1],
-                        backend='numpy')
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1])
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1'],
-                        out_order=[],
-                        backend='numpy')
+                        out_order=[])
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1', 'i2'],
-                        out_order=['i1'],
-                        backend='numpy')
+                        out_order=['i1'])
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1', 'i1', 'i2'],
-                        out_order=[],
-                        backend='numpy')
+                        out_order=[])
 
 
-def test_out_of_order_contraction_numpy_backend():
-  a = np.ones((2, 2, 2))
+def test_out_of_order_contraction():
+  a = tf.ones((2, 2, 2))
   with pytest.warns(UserWarning, match='Suboptimal ordering'):
-    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)],
-                        backend='numpy')
+    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)])
 
 
-def test_output_order_numpy_backend():
+def test_output_order():
   a = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a], [(-2, -1)], backend='numpy')
+  res = ncon_interface.ncon([a], [(-2, -1)])
   np.testing.assert_allclose(res, a.transpose())
 
 
-def test_outer_product_numpy_backend():
+def test_outer_product():
   a = np.array([1, 2, 3])
   b = np.array([1, 2])
-  res = ncon_interface.ncon([a, b], [(-1,), (-2,)], backend='numpy')
+  res = ncon_interface.ncon([a, b], [(-1,), (-2,)])
   np.testing.assert_allclose(res, np.kron(a, b).reshape((3, 2)))
-  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)],
-                            backend='numpy')
-  assert res == 196
+  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)])
+  assert res.numpy() == 196
 
 
-def test_trace_numpy_backend():
-  a = np.ones((2, 2))
-  res = ncon_interface.ncon([a], [(1, 1)], backend='numpy')
-  assert res == 2
+def test_trace():
+  a = tf.ones((2, 2))
+  res = ncon_interface.ncon([a], [(1, 1)])
+  assert res.numpy() == 2
 
 
-def test_small_matmul_numpy_backend():
+def test_small_matmul():
   a = np.random.randn(2, 2)
   b = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)], backend='numpy')
+  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)])
   np.testing.assert_allclose(res, a.transpose() @ b)
 
 
-def test_contraction_numpy_backend():
+def test_contraction():
   a = np.random.randn(2, 2, 2)
-  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)],
-                            backend='numpy')
+  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)])
   res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
   res_np = res_np.reshape((2, 2, 2))
   np.testing.assert_allclose(res, res_np)
 
 
-def test_backend_network_numpy_backend():
+def test_backend_network():
   a = np.random.randn(2, 2, 2)
   tn, _, _ = ncon_interface.ncon_network([a, a, a], [(-1, 1, 2), (1, 2, 3),
                                                      (3, -2, -3)],
                                          backend="numpy")
   assert tn.backend.name == "numpy"
-
-  res = naive(tn).get_final_node().get_tensor()
-  res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
-  res_np = res_np.reshape((2, 2, 2))
-  np.testing.assert_allclose(res, res_np)
-
-
-def test_sanity_check_tensorflow_backend():
-  result = ncon_interface.ncon([tf.ones(
-      (2, 2)), tf.ones((2, 2))], [(-1, 1), (1, -2)], backend='tensorflow')
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
-
-
-def test_order_spec_tensorflow_backend():
-  a = tf.ones((2, 2))
-
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2],
-                               backend='tensorflow')
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
-
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1],
-                               backend='tensorflow')
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
-
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)],
-                               con_order=[1],
-                               out_order=[-1, -2],
-                               backend='tensorflow')
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
-
-
-def test_order_spec_noninteger_tensorflow_backend():
-  a = tf.ones((2, 2))
-  result = ncon_interface.ncon([a, a], [('o1', 'i'), ('i', 'o2')],
-                               con_order=['i'],
-                               out_order=['o1', 'o2'],
-                               backend='tensorflow')
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
-
-
-def test_invalid_network_tensorflow_backend():
-  a = tf.ones((2, 2))
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)], backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 2)], backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (3, 1)], backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)], backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 't')], backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(0, 1), (1, 0)], backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1,), (1, 2)], backend='tensorflow')
-
-
-def test_invalid_order_tensorflow_backend():
-  a = tf.ones((2, 2))
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3],
-                        backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1],
-                        backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
-                        con_order=['i1'],
-                        out_order=[],
-                        backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
-                        con_order=['i1', 'i2'],
-                        out_order=['i1'],
-                        backend='tensorflow')
-  with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
-                        con_order=['i1', 'i1', 'i2'],
-                        out_order=[],
-                        backend='tensorflow')
-
-
-def test_out_of_order_contraction_tensorflow_backend():
-  a = tf.ones((2, 2, 2))
-  with pytest.warns(UserWarning, match='Suboptimal ordering'):
-    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)],
-                        backend='tensorflow')
-
-
-def test_output_order_tensorflow_backend():
-  a = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a], [(-2, -1)], backend='tensorflow')
-  np.testing.assert_allclose(res, a.transpose())
-
-
-def test_outer_product_tensorflow_backend():
-  a = np.array([1, 2, 3])
-  b = np.array([1, 2])
-  res = ncon_interface.ncon([a, b], [(-1,), (-2,)], backend='tensorflow')
-  np.testing.assert_allclose(res, np.kron(a, b).reshape((3, 2)))
-  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)],
-                            backend='tensorflow')
-  assert res.numpy() == 196
-
-
-def test_trace_tensorflow_backend():
-  a = tf.ones((2, 2))
-  res = ncon_interface.ncon([a], [(1, 1)], backend='tensorflow')
-  assert res.numpy() == 2
-
-
-def test_small_matmul_tensorflow_backend():
-  a = np.random.randn(2, 2)
-  b = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)], backend='tensorflow')
-  np.testing.assert_allclose(res, a.transpose() @ b)
-
-
-def test_contraction_tensorflow_backend():
-  a = np.random.randn(2, 2, 2)
-  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)],
-                            backend='tensorflow')
-  res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
-  res_np = res_np.reshape((2, 2, 2))
-  np.testing.assert_allclose(res, res_np)
-
-
-def test_backend_network_tensorflow_backend():
-  a = np.random.randn(2, 2, 2)
-  tn, _, _ = ncon_interface.ncon_network([a, a, a], [(-1, 1, 2), (1, 2, 3),
-                                                     (3, -2, -3)],
-                                         backend="tensorflow")
-  assert tn.backend.name == "tensorflow"
 
   res = naive(tn).get_final_node().get_tensor()
   res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -21,19 +21,19 @@ from tensornetwork import ncon_interface
 from tensornetwork.contractors.naive_contractor import naive
 
 
-def test_sanity_check():
+def test_sanity_check(backend):
   result = ncon_interface.ncon([np.ones(
-      (2, 2)), np.ones((2, 2))], [(-1, 1), (1, -2)])
+      (2, 2)), np.ones((2, 2))], [(-1, 1), (1, -2)], backend=backend)
   np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
-def test_order_spec():
+def test_order_spec(backend):
   a = np.ones((2, 2))
 
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2])
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2], backend=backend)
   np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1])
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1], backend=backend)
   np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
   result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)],
@@ -42,101 +42,107 @@ def test_order_spec():
   np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
-def test_order_spec_noninteger():
+def test_order_spec_noninteger(backend):
   a = np.ones((2, 2))
   result = ncon_interface.ncon([a, a], [('o1', 'i'), ('i', 'o2')],
                                con_order=['i'],
-                               out_order=['o1', 'o2'])
+                               out_order=['o1', 'o2'], backend=backend)
   np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
-def test_invalid_network():
+def test_invalid_network(backend):
   a = np.ones((2, 2))
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)], backend=backend)
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 2)])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 2)], backend=backend)
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (3, 1)])
+    ncon_interface.ncon([a, a], [(1, 2), (3, 1)], backend=backend)
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)], backend=backend)
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 't')])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 't')], backend=backend)
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(0, 1), (1, 0)])
+    ncon_interface.ncon([a, a], [(0, 1), (1, 0)], backend=backend)
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1,), (1, 2)])
+    ncon_interface.ncon([a, a], [(1,), (1, 2)], backend=backend)
 
 
-def test_invalid_order():
+def test_invalid_order(backend):
   a = np.ones((2, 2))
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3], 
+        backend=backend)
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1], 
+        backend=backend)
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1'],
-                        out_order=[])
+                        out_order=[], backend=backend)
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1', 'i2'],
-                        out_order=['i1'])
+                        out_order=['i1'], backend=backend)
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1', 'i1', 'i2'],
-                        out_order=[])
+                        out_order=[], backend=backend)
 
 
-def test_out_of_order_contraction():
+def test_out_of_order_contraction(backend):
   a = np.ones((2, 2, 2))
   with pytest.warns(UserWarning, match='Suboptimal ordering'):
-    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)])
+    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)],
+        backend=backend)
 
 
-def test_output_order():
+def test_output_order(backend):
   a = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a], [(-2, -1)])
+  res = ncon_interface.ncon([a], [(-2, -1)], backend=backend)
   np.testing.assert_allclose(res, a.transpose())
 
 
-def test_outer_product():
+def test_outer_product(backend):
+  if backend == "jax":
+    pytest.skip("Jax outer product support is currently broken.")
   a = np.array([1, 2, 3])
   b = np.array([1, 2])
-  res = ncon_interface.ncon([a, b], [(-1,), (-2,)])
+  res = ncon_interface.ncon([a, b], [(-1,), (-2,)], backend=backend)
   np.testing.assert_allclose(res, np.kron(a, b).reshape((3, 2)))
-  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)])
+  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)],
+      backend=backend)
   np.testing.assert_allclose(res, 196)
 
 
-def test_trace():
+def test_trace(backend):
   a = np.ones((2, 2))
-  res = ncon_interface.ncon([a], [(1, 1)])
+  res = ncon_interface.ncon([a], [(1, 1)], backend=backend)
   np.testing.assert_allclose(res, 2)
 
 
-def test_small_matmul():
+def test_small_matmul(backend):
   a = np.random.randn(2, 2)
   b = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)])
+  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)],
+      backend=backend)
   np.testing.assert_allclose(res, a.transpose() @ b)
 
 
-def test_contraction():
+def test_contraction(backend):
   a = np.random.randn(2, 2, 2)
-  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)])
+  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)],
+      backend=backend)
   res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
   res_np = res_np.reshape((2, 2, 2))
   np.testing.assert_allclose(res, res_np)
 
 
-def test_backend_network():
+def test_backend_network(backend):
   a = np.random.randn(2, 2, 2)
   tn, _, _ = ncon_interface.ncon_network([a, a, a], [(-1, 1, 2), (1, 2, 3),
                                                      (3, -2, -3)],
-                                         backend="numpy")
-  assert tn.backend.name == "numpy"
-
+                                         backend=backend)
   res = naive(tn).get_final_node().get_tensor()
   res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
   res_np = res_np.reshape((2, 2, 2))

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -23,121 +23,267 @@ from tensornetwork import ncon_interface
 from tensornetwork.contractors.naive_contractor import naive
 
 
-def test_sanity_check():
-  result = ncon_interface.ncon([tf.ones(
-      (2, 2)), tf.ones((2, 2))], [(-1, 1), (1, -2)])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+def test_sanity_check_numpy_backend():
+  result = ncon_interface.ncon([np.ones(
+      (2, 2)), np.ones((2, 2))], [(-1, 1), (1, -2)], backend='numpy')
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
-def test_order_spec():
-  a = tf.ones((2, 2))
+def test_order_spec_numpy_backend():
+  a = np.ones((2, 2))
 
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2],
+                               backend='numpy')
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
-  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1],
+                               backend='numpy')
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
   result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)],
                                con_order=[1],
-                               out_order=[-1, -2])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+                               out_order=[-1, -2],
+                               backend='numpy')
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
-def test_order_spec_noninteger():
-  a = tf.ones((2, 2))
+def test_order_spec_noninteger_numpy_backend():
+  a = np.ones((2, 2))
   result = ncon_interface.ncon([a, a], [('o1', 'i'), ('i', 'o2')],
                                con_order=['i'],
-                               out_order=['o1', 'o2'])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+                               out_order=['o1', 'o2'],
+                               backend='numpy')
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
-def test_invalid_network():
-  a = tf.ones((2, 2))
+def test_invalid_network_numpy_backend():
+  a = np.ones((2, 2))
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)], backend='numpy')
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 2)])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 2)], backend='numpy')
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (3, 1)])
+    ncon_interface.ncon([a, a], [(1, 2), (3, 1)], backend='numpy')
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)], backend='numpy')
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 't')])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 't')], backend='numpy')
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(0, 1), (1, 0)])
+    ncon_interface.ncon([a, a], [(0, 1), (1, 0)], backend='numpy')
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1,), (1, 2)])
+    ncon_interface.ncon([a, a], [(1,), (1, 2)], backend='numpy')
 
 
-def test_invalid_order():
-  a = tf.ones((2, 2))
+def test_invalid_order_numpy_backend():
+  a = np.ones((2, 2))
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3],
+                        backend='numpy')
   with pytest.raises(ValueError):
-    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1])
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1],
+                        backend='numpy')
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1'],
-                        out_order=[])
+                        out_order=[],
+                        backend='numpy')
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1', 'i2'],
-                        out_order=['i1'])
+                        out_order=['i1'],
+                        backend='numpy')
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
                         con_order=['i1', 'i1', 'i2'],
-                        out_order=[])
+                        out_order=[],
+                        backend='numpy')
 
 
-def test_out_of_order_contraction():
-  a = tf.ones((2, 2, 2))
+def test_out_of_order_contraction_numpy_backend():
+  a = np.ones((2, 2, 2))
   with pytest.warns(UserWarning, match='Suboptimal ordering'):
-    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)])
+    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)],
+                        backend='numpy')
 
 
-def test_output_order():
+def test_output_order_numpy_backend():
   a = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a], [(-2, -1)])
+  res = ncon_interface.ncon([a], [(-2, -1)], backend='numpy')
   np.testing.assert_allclose(res, a.transpose())
 
 
-def test_outer_product():
+def test_outer_product_numpy_backend():
   a = np.array([1, 2, 3])
   b = np.array([1, 2])
-  res = ncon_interface.ncon([a, b], [(-1,), (-2,)])
+  res = ncon_interface.ncon([a, b], [(-1,), (-2,)], backend='numpy')
   np.testing.assert_allclose(res, np.kron(a, b).reshape((3, 2)))
-  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)])
-  assert res.numpy() == 196
+  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)],
+                            backend='numpy')
+  assert res == 196
 
 
-def test_trace():
-  a = tf.ones((2, 2))
-  res = ncon_interface.ncon([a], [(1, 1)])
-  assert res.numpy() == 2
+def test_trace_numpy_backend():
+  a = np.ones((2, 2))
+  res = ncon_interface.ncon([a], [(1, 1)], backend='numpy')
+  assert res == 2
 
 
-def test_small_matmul():
+def test_small_matmul_numpy_backend():
   a = np.random.randn(2, 2)
   b = np.random.randn(2, 2)
-  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)])
+  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)], backend='numpy')
   np.testing.assert_allclose(res, a.transpose() @ b)
 
 
-def test_contraction():
+def test_contraction_numpy_backend():
   a = np.random.randn(2, 2, 2)
-  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)])
+  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)],
+                            backend='numpy')
   res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
   res_np = res_np.reshape((2, 2, 2))
   np.testing.assert_allclose(res, res_np)
 
 
-def test_backend_network():
+def test_backend_network_numpy_backend():
   a = np.random.randn(2, 2, 2)
   tn, _, _ = ncon_interface.ncon_network([a, a, a], [(-1, 1, 2), (1, 2, 3),
                                                      (3, -2, -3)],
                                          backend="numpy")
   assert tn.backend.name == "numpy"
+
+  res = naive(tn).get_final_node().get_tensor()
+  res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
+  res_np = res_np.reshape((2, 2, 2))
+  np.testing.assert_allclose(res, res_np)
+
+
+def test_sanity_check_tensorflow_backend():
+  result = ncon_interface.ncon([tf.ones(
+      (2, 2)), tf.ones((2, 2))], [(-1, 1), (1, -2)], backend='tensorflow')
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+
+def test_order_spec_tensorflow_backend():
+  a = tf.ones((2, 2))
+
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2],
+                               backend='tensorflow')
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1],
+                               backend='tensorflow')
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+  result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)],
+                               con_order=[1],
+                               out_order=[-1, -2],
+                               backend='tensorflow')
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+
+def test_order_spec_noninteger_tensorflow_backend():
+  a = tf.ones((2, 2))
+  result = ncon_interface.ncon([a, a], [('o1', 'i'), ('i', 'o2')],
+                               con_order=['i'],
+                               out_order=['o1', 'o2'],
+                               backend='tensorflow')
+  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+
+
+def test_invalid_network_tensorflow_backend():
+  a = tf.ones((2, 2))
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)], backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 2)], backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (3, 1)], backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 0.1)], backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 't')], backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(0, 1), (1, 0)], backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1,), (1, 2)], backend='tensorflow')
+
+
+def test_invalid_order_tensorflow_backend():
+  a = tf.ones((2, 2))
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3],
+                        backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [(1, 2), (2, 1)], out_order=[-1],
+                        backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
+                        con_order=['i1'],
+                        out_order=[],
+                        backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
+                        con_order=['i1', 'i2'],
+                        out_order=['i1'],
+                        backend='tensorflow')
+  with pytest.raises(ValueError):
+    ncon_interface.ncon([a, a], [('i1', 'i2'), ('i1', 'i2')],
+                        con_order=['i1', 'i1', 'i2'],
+                        out_order=[],
+                        backend='tensorflow')
+
+
+def test_out_of_order_contraction_tensorflow_backend():
+  a = tf.ones((2, 2, 2))
+  with pytest.warns(UserWarning, match='Suboptimal ordering'):
+    ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)],
+                        backend='tensorflow')
+
+
+def test_output_order_tensorflow_backend():
+  a = np.random.randn(2, 2)
+  res = ncon_interface.ncon([a], [(-2, -1)], backend='tensorflow')
+  np.testing.assert_allclose(res, a.transpose())
+
+
+def test_outer_product_tensorflow_backend():
+  a = np.array([1, 2, 3])
+  b = np.array([1, 2])
+  res = ncon_interface.ncon([a, b], [(-1,), (-2,)], backend='tensorflow')
+  np.testing.assert_allclose(res, np.kron(a, b).reshape((3, 2)))
+  res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)],
+                            backend='tensorflow')
+  assert res.numpy() == 196
+
+
+def test_trace_tensorflow_backend():
+  a = tf.ones((2, 2))
+  res = ncon_interface.ncon([a], [(1, 1)], backend='tensorflow')
+  assert res.numpy() == 2
+
+
+def test_small_matmul_tensorflow_backend():
+  a = np.random.randn(2, 2)
+  b = np.random.randn(2, 2)
+  res = ncon_interface.ncon([a, b], [(1, -1), (1, -2)], backend='tensorflow')
+  np.testing.assert_allclose(res, a.transpose() @ b)
+
+
+def test_contraction_tensorflow_backend():
+  a = np.random.randn(2, 2, 2)
+  res = ncon_interface.ncon([a, a, a], [(-1, 1, 2), (1, 2, 3), (3, -2, -3)],
+                            backend='tensorflow')
+  res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))
+  res_np = res_np.reshape((2, 2, 2))
+  np.testing.assert_allclose(res, res_np)
+
+
+def test_backend_network_tensorflow_backend():
+  a = np.random.randn(2, 2, 2)
+  tn, _, _ = ncon_interface.ncon_network([a, a, a], [(-1, 1, 2), (1, 2, 3),
+                                                     (3, -2, -3)],
+                                         backend="tensorflow")
+  assert tn.backend.name == "tensorflow"
 
   res = naive(tn).get_final_node().get_tensor()
   res_np = a.reshape((2, 4)) @ a.reshape((4, 2)) @ a.reshape((2, 4))

--- a/tensornetwork/ncon_interface_test.py
+++ b/tensornetwork/ncon_interface_test.py
@@ -17,43 +17,41 @@ from __future__ import division
 from __future__ import print_function
 import pytest
 import numpy as np
-import tensorflow as tf
-tf.compat.v1.enable_v2_behavior()
 from tensornetwork import ncon_interface
 from tensornetwork.contractors.naive_contractor import naive
 
 
 def test_sanity_check():
-  result = ncon_interface.ncon([tf.ones(
-      (2, 2)), tf.ones((2, 2))], [(-1, 1), (1, -2)])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+  result = ncon_interface.ncon([np.ones(
+      (2, 2)), np.ones((2, 2))], [(-1, 1), (1, -2)])
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
 def test_order_spec():
-  a = tf.ones((2, 2))
+  a = np.ones((2, 2))
 
   result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], out_order=[-1, -2])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
   result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)], con_order=[1])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
   result = ncon_interface.ncon([a, a], [(-1, 1), (1, -2)],
                                con_order=[1],
                                out_order=[-1, -2])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
 def test_order_spec_noninteger():
-  a = tf.ones((2, 2))
+  a = np.ones((2, 2))
   result = ncon_interface.ncon([a, a], [('o1', 'i'), ('i', 'o2')],
                                con_order=['i'],
                                out_order=['o1', 'o2'])
-  np.testing.assert_allclose(result, tf.ones((2, 2)) * 2)
+  np.testing.assert_allclose(result, np.ones((2, 2)) * 2)
 
 
 def test_invalid_network():
-  a = tf.ones((2, 2))
+  a = np.ones((2, 2))
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [(1, 2), (2, 1), (1, 2)])
   with pytest.raises(ValueError):
@@ -71,7 +69,7 @@ def test_invalid_network():
 
 
 def test_invalid_order():
-  a = tf.ones((2, 2))
+  a = np.ones((2, 2))
   with pytest.raises(ValueError):
     ncon_interface.ncon([a, a], [(1, 2), (2, 1)], con_order=[2, 3])
   with pytest.raises(ValueError):
@@ -91,7 +89,7 @@ def test_invalid_order():
 
 
 def test_out_of_order_contraction():
-  a = tf.ones((2, 2, 2))
+  a = np.ones((2, 2, 2))
   with pytest.warns(UserWarning, match='Suboptimal ordering'):
     ncon_interface.ncon([a, a, a], [(-1, 1, 3), (1, 3, 2), (2, -2, -3)])
 
@@ -108,13 +106,13 @@ def test_outer_product():
   res = ncon_interface.ncon([a, b], [(-1,), (-2,)])
   np.testing.assert_allclose(res, np.kron(a, b).reshape((3, 2)))
   res = ncon_interface.ncon([a, a, a, a], [(1,), (1,), (2,), (2,)])
-  assert res.numpy() == 196
+  np.testing.assert_allclose(res, 196)
 
 
 def test_trace():
-  a = tf.ones((2, 2))
+  a = np.ones((2, 2))
   res = ncon_interface.ncon([a], [(1, 1)])
-  assert res.numpy() == 2
+  np.testing.assert_allclose(res, 2)
 
 
 def test_small_matmul():

--- a/tensornetwork/network_components_test.py
+++ b/tensornetwork/network_components_test.py
@@ -6,7 +6,6 @@ import h5py
 from tensornetwork.network_components import Node, CopyNode, Edge
 import tensornetwork
 
-tf.compat.v1.enable_v2_behavior()
 
 string_type = h5py.special_dtype(vlen=str)
 

--- a/tensornetwork/tests/network_test.py
+++ b/tensornetwork/tests/network_test.py
@@ -22,11 +22,7 @@ import tensorflow as tf
 import torch
 import jax
 from jax.config import config
-import tensornetwork.config as config_file
 
-
-config.update("jax_enable_x64", True)
-tf.compat.v1.enable_v2_behavior()
 
 np_dtypes = [np.float32, np.float64, np.complex64, np.complex128, np.int32]
 tf_dtypes = [tf.float32, tf.float64, tf.complex64, tf.complex128, tf.int32]

--- a/tensornetwork/tests/serialization_test.py
+++ b/tensornetwork/tests/serialization_test.py
@@ -18,13 +18,7 @@ from __future__ import print_function
 import tensornetwork
 import io
 import numpy as np
-import tensorflow as tf
-from jax.config import config
 import h5py
-
-
-config.update("jax_enable_x64", True)
-tf.compat.v1.enable_v2_behavior()
 
 
 def test_save_makes_hdf5_file(tmp_path, backend):

--- a/tensornetwork/tests/split_node_test.py
+++ b/tensornetwork/tests/split_node_test.py
@@ -18,13 +18,6 @@ from __future__ import print_function
 import tensornetwork
 import pytest
 import numpy as np
-import tensorflow as tf
-from jax.config import config
-import tensornetwork.config as config_file
-
-
-config.update("jax_enable_x64", True)
-tf.compat.v1.enable_v2_behavior()
 
 
 def test_split_node_qr_disable(backend):

--- a/tensornetwork/tests/tensornetwork_test.py
+++ b/tensornetwork/tests/tensornetwork_test.py
@@ -21,12 +21,7 @@ import numpy as np
 import tensorflow as tf
 import torch
 import jax
-from jax.config import config
-import tensornetwork.config as config_file
 
-
-config.update("jax_enable_x64", True)
-tf.compat.v1.enable_v2_behavior()
 
 np_dtypes = [np.float32, np.float64, np.complex64, np.complex128, np.int32]
 tf_dtypes = [tf.float32, tf.float64, tf.complex64, tf.complex128, tf.int32]


### PR DESCRIPTION
fixes #262 

* removed all occurrences of setting default backend in tests and replaced with fixture
* `jax.config.update("jax_enable_x64", True)` is still set globally in tests, not sure if this is expected
* to make this future proof, it can be a good idea to do an explicit autoused fixture that resets all backend and configs to defaults, @Thenerdstation , wdyt?
