### PR TITLE
Removed TensorNetwork from tests/

### DIFF
--- a/tensornetwork/__init__.py
+++ b/tensornetwork/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from tensornetwork.network import TensorNetwork
 from tensornetwork.network_components import Node, Edge, CopyNode, BaseNode
 #pylint: disable=line-too-long
-from tensornetwork.network_operations import conj, transpose, split_node, split_node_qr, split_node_rq, split_node_full_svd, reachable, check_connected, check_correct, get_all_nodes, get_all_edges
+from tensornetwork.network_operations import conj, copy, transpose, split_node, split_node_qr, split_node_rq, split_node_full_svd, reachable, check_connected, check_correct, get_all_nodes, get_all_edges, remove_node
 
 from tensornetwork.network_components import contract, contract_copy_node, contract_between, outer_product, outer_product_final_nodes, contract_parallel, flatten_edges, get_all_nondangling, flatten_all_edges, flatten_edges_between, get_parallel_edges, get_shared_edges
 

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -1,3 +1,4 @@
+# pytype: skip-file
 """Tests for graphmode_tensornetwork."""
 from __future__ import absolute_import
 from __future__ import division

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -1,3 +1,4 @@
+# pytype: skip-file
 # Copyright 2019 The TensorNetwork Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -1,3 +1,4 @@
+# pytype: skip-file
 """Tests for graphmode_tensornetwork."""
 from __future__ import absolute_import
 from __future__ import division

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -1000,7 +1000,7 @@ class TensorNetwork:
     for i, name in enumerate(node.axis_names):
       print(i, name)
       if not node[i].is_dangling() and not node[i].is_trace():
-        edge1, edge2 = disconnect(node[i])
+        edge1, edge2 = self.disconnect(node[i])
         new_broken_edge = edge1 if edge1.node1 is not node else edge2
         broken_edges_by_axis[i] = new_broken_edge
         broken_edges_by_name[name] = new_broken_edge

--- a/tensornetwork/network.py
+++ b/tensornetwork/network.py
@@ -1000,7 +1000,7 @@ class TensorNetwork:
     for i, name in enumerate(node.axis_names):
       print(i, name)
       if not node[i].is_dangling() and not node[i].is_trace():
-        edge1, edge2 = self.disconnect(node[i])
+        edge1, edge2 = disconnect(node[i])
         new_broken_edge = edge1 if edge1.node1 is not node else edge2
         broken_edges_by_axis[i] = new_broken_edge
         broken_edges_by_name[name] = new_broken_edge

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -20,7 +20,6 @@ import collections
 from typing import Any, Dict, List, Optional, Set, Text, Tuple, Type, Union, \
   overload, Sequence
 import numpy as np
-import weakref
 from abc import ABC
 from abc import abstractmethod
 import h5py
@@ -98,7 +97,7 @@ class BaseNode(ABC):
     if axis_names is not None:
       self.add_axis_names(axis_names)
     else:
-      self._axis_names = None
+      self._axis_names = [str(i) for i in range(len(shape))]
 
     self._signature = -1
 
@@ -939,9 +938,9 @@ class Edge:
     if self.is_disabled:
       raise ValueError(
           'Edge has been disabled, accessing node1 is no longer possible')
-    if self._node1() is None:
+    if self._node1 is None:
       raise ValueError("node1 for edge '{}' no longer exists.".format(self))
-    return self._node1()
+    return self._node1
 
   @property
   def node2(self) -> Optional[BaseNode]:
@@ -950,9 +949,9 @@ class Edge:
           'Edge has been disabled, accessing node2 is no longer possible')
     if self._is_dangling:
       return None
-    if self._node2() is None:
+    if self._node2 is None:
       raise ValueError("node2 for edge '{}' no longer exists.".format(self))
-    return self._node2()
+    return self._node2
 
   @node1.setter
   def node1(self, node: BaseNode) -> None:
@@ -960,7 +959,7 @@ class Edge:
       raise ValueError(
           'Edge has been disabled, setting node1 is no longer possible')
     # pylint: disable=attribute-defined-outside-init
-    self._node1 = weakref.ref(node)
+    self._node1 = node
 
   @node2.setter
   def node2(self, node: Optional[BaseNode]) -> None:
@@ -968,7 +967,7 @@ class Edge:
       raise ValueError(
           'Edge has been disabled, setting node2 is no longer possible')
     # pylint: disable=attribute-defined-outside-init
-    self._node2 = weakref.ref(node) if node else None
+    self._node2 = node
     if node is None:
       self._is_dangling = True
 
@@ -1075,9 +1074,9 @@ class Edge:
     if self.is_dangling():
       raise ValueError("Cannot break dangling edge {}.".format(self))
     if not edge1_name:
-      edge1_name = '__unnamed_edge__'
+      edge1_name = '__broke_edge1__{}'.format(self.name)
     if not edge2_name:
-      edge2_name = '__unnamed_edge__'
+      edge2_name = '__broke_edge2__{}'.format(self.name)
 
     node1 = self.node1
     node2 = self.node2
@@ -1254,7 +1253,7 @@ def flatten_edges(edges: List[Edge],
     if axis_names:
       node.axis_names = [axis_names[n] for n in range(len(node.edges))]
     else:
-      node.axis_names = None
+      node.axis_names = ["__unnamed_edge__" for n in range(len(node.edges))]
 
   node1, node2 = tuple(expected_nodes)
   # Sets are returned in a random order, so this is how we deal with
@@ -1587,8 +1586,8 @@ def connect(edge1: Edge, edge2: Edge, name: Optional[Text] = None) -> Edge:
   return new_edge
 
 
-def disconnect(edge, edge1_name: Optional[Text],
-               edge2_name: Optional[Text]) -> Tuple[Edge, Edge]:
+def disconnect(edge, edge1_name: Optional[Text] = None,
+               edge2_name: Optional[Text] = None) -> Tuple[Edge, Edge]:
   """
   Break an existing non-dangling edge.
   This updates both Edge.node1 and Edge.node2 by removing the 

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -1074,9 +1074,9 @@ class Edge:
     if self.is_dangling():
       raise ValueError("Cannot break dangling edge {}.".format(self))
     if not edge1_name:
-      edge1_name = '__broke_edge1__{}'.format(self.name)
+      edge1_name = '__disconnected_edge1_of_{}__'.format(self.name)
     if not edge2_name:
-      edge2_name = '__broke_edge2__{}'.format(self.name)
+      edge2_name = '__disconnected_edge2_of_{}__'.format(self.name)
 
     node1 = self.node1
     node2 = self.node2
@@ -1093,8 +1093,7 @@ class Edge:
     """
     if self is not other:
       raise ValueError('Cannot break two unconnected edges')
-    return self.disconnect('__unnamed_edge__', '__unnamed_dge__')
-
+    return self.disconnect()
 
 def get_shared_edges(node1: BaseNode, node2: BaseNode) -> Set[Edge]:
   """Get all edges shared between two nodes.

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -1253,7 +1253,7 @@ def flatten_edges(edges: List[Edge],
     if axis_names:
       node.axis_names = [axis_names[n] for n in range(len(node.edges))]
     else:
-      node.axis_names = ["__unnamed_edge__" for n in range(len(node.edges))]
+      node.axis_names = [str(n) for n in range(len(node.edges))]
 
   node1, node2 = tuple(expected_nodes)
   # Sets are returned in a random order, so this is how we deal with

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 import collections
 from typing import Any, Dict, List, Optional, Set, Text, Tuple, Type, Union, \
-  overload, Sequence
+  overload, Sequence, Iterable
 import numpy as np
 from abc import ABC
 from abc import abstractmethod
@@ -1131,7 +1131,7 @@ def get_parallel_edges(edge: Edge) -> Set[Edge]:
 
 
 def get_all_nondangling(
-    nodes: Union[List[BaseNode], Set[BaseNode]]) -> Set[Edge]:
+    nodes: Union[Iterable[BaseNode]]) -> Set[Edge]:
   """Return the set of all non-dangling edges."""
   edges = set()
   for node in nodes:
@@ -1287,7 +1287,7 @@ def flatten_edges_between(
   return None
 
 
-def flatten_all_edges(nodes: List[BaseNode]) -> List[Edge]:
+def flatten_all_edges(nodes: Iterable[BaseNode]) -> List[Edge]:
   """Flatten all edges in the network.
 
   Returns:

--- a/tensornetwork/network_operations.py
+++ b/tensornetwork/network_operations.py
@@ -152,24 +152,24 @@ def remove_node(node: BaseNode
     node: The node to be removed.
 
   Returns:
-    broken_edges_by_name: A Dictionary mapping `node`'s axis names to
-      the newly broken edges.
-    broken_edges_by_axis: A Dictionary mapping `node`'s axis numbers
-      to the newly broken edges.
+    A tuple of:
+      disconnected_edges_by_name: A Dictionary mapping `node`'s axis names to
+        the newly broken edges.
+      disconnected_edges_by_axis: A Dictionary mapping `node`'s axis numbers
+        to the newly broken edges.
 
   Raises:
     ValueError: If the node isn't in the network.
   """
-  broken_edges_by_name = {}
-  broken_edges_by_axis = {}
+  disconnected_edges_by_name = {}
+  disconnected_edges_by_axis = {}
   for i, name in enumerate(node.axis_names):
     if not node[i].is_dangling() and not node[i].is_trace():
       edge1, edge2 = disconnect(node[i])
-      new_broken_edge = edge1 if edge1.node1 is not node else edge2
-      broken_edges_by_axis[i] = new_broken_edge
-      broken_edges_by_name[name] = new_broken_edge
-  node.disable()
-  return broken_edges_by_name, broken_edges_by_axis
+      new_disconnected_edge = edge1 if edge1.node1 is not node else edge2
+      disconnected_edges_by_axis[i] = new_disconnected_edge
+      disconnected_edges_by_name[name] = new_disconnected_edge
+  return disconnected_edges_by_name, disconnected_edges_by_axis
 
 def split_node(
     node: BaseNode,

--- a/tensornetwork/network_operations.py
+++ b/tensornetwork/network_operations.py
@@ -23,6 +23,7 @@ import numpy as np
 
 #pylint: disable=useless-import-alias
 import tensornetwork.config as config
+#pylint: disable=line-too-long
 from tensornetwork.network_components import BaseNode, Node, CopyNode, Edge, disconnect
 from tensornetwork.backends import backend_factory
 from tensornetwork.backends.base_backend import BaseBackend
@@ -91,13 +92,13 @@ def transpose(node: BaseNode,
       backend=node.backend.name)
   return new_node.reorder_axes(perm)
 
-def copy(nodes: Iterable[BaseNode], conj: bool = False) -> Tuple[dict, dict]:
+def copy(nodes: Iterable[BaseNode], conjugate: bool = False) -> Tuple[dict, dict]:
   """
 
   Return a copy of the TensorNetwork.
   Args:
     nodes: An `Iterable` (Usually a `List` or `Set`) of `Nodes`.
-    conj: Boolean. Whether to conjugate all of the nodes in the
+    conjugate: Boolean. Whether to conjugate all of the nodes in the
       `TensorNetwork` (useful for calculating norms and reduced density
       matrices).
   Returns:
@@ -108,7 +109,7 @@ def copy(nodes: Iterable[BaseNode], conj: bool = False) -> Tuple[dict, dict]:
                  network to the edges of the copy.
   """
   #TODO: add support for copying CopyTensor
-  if conj:
+  if conjugate:
     node_dict = {
         node: Node(
             node.backend.conj(node.tensor),
@@ -132,7 +133,7 @@ def copy(nodes: Iterable[BaseNode], conj: bool = False) -> Tuple[dict, dict]:
       node2 = edge.node2
       axis2 = edge.node2.get_axis_number(edge.axis2)
       new_edge = Edge(node_dict[node1], axis1, edge.name,
-                                         node_dict[node2], axis2)
+                      node_dict[node2], axis2)
       new_edge.set_signature(edge.signature)
     else:
       new_edge = Edge(node_dict[node1], axis1, edge.name)
@@ -642,7 +643,7 @@ def get_all_nodes(edges: Union[List[Edge], Set[Edge]]) -> Set[BaseNode]:
   return nodes
 
 
-def get_all_edges(nodes: Union[List[BaseNode], Set[BaseNode]]) -> Set[Edge]:
+def get_all_edges(nodes: Union[Iterable[BaseNode]]) -> Set[Edge]:
   """Return the set of edges of all nodes."""
   edges = set()
   for node in nodes:

--- a/tensornetwork/network_operations.py
+++ b/tensornetwork/network_operations.py
@@ -23,7 +23,7 @@ import numpy as np
 
 #pylint: disable=useless-import-alias
 import tensornetwork.config as config
-from tensornetwork.network_components import BaseNode, Node, CopyNode, Edge
+from tensornetwork.network_components import BaseNode, Node, CopyNode, Edge, disconnect
 from tensornetwork.backends import backend_factory
 from tensornetwork.backends.base_backend import BaseBackend
 from tensornetwork.network_components import connect
@@ -91,6 +91,84 @@ def transpose(node: BaseNode,
       backend=node.backend.name)
   return new_node.reorder_axes(perm)
 
+def copy(nodes: Iterable[BaseNode], conj: bool = False) -> Tuple[dict, dict]:
+  """
+
+  Return a copy of the TensorNetwork.
+  Args:
+    nodes: An `Iterable` (Usually a `List` or `Set`) of `Nodes`.
+    conj: Boolean. Whether to conjugate all of the nodes in the
+      `TensorNetwork` (useful for calculating norms and reduced density
+      matrices).
+  Returns:
+    A tuple containing:
+      node_dict: A dictionary mapping the nodes of the original
+                 network to the nodes of the copy.
+      edge_dict: A dictionary mapping the edges of the original
+                 network to the edges of the copy.
+  """
+  #TODO: add support for copying CopyTensor
+  if conj:
+    node_dict = {
+        node: Node(
+            node.backend.conj(node.tensor),
+            name=node.name,
+            axis_names=node.axis_names,
+            backend=node.backend.name) for node in nodes
+    }
+  else:
+    node_dict = {
+        node: Node(
+            node.tensor, name=node.name, axis_names=node.axis_names, 
+            backend=node.backend.name)
+        for node in nodes
+    }
+  edge_dict = {}
+  for edge in get_all_edges(nodes):
+    node1 = edge.node1
+    axis1 = edge.node1.get_axis_number(edge.axis1)
+
+    if not edge.is_dangling():
+      node2 = edge.node2
+      axis2 = edge.node2.get_axis_number(edge.axis2)
+      new_edge = Edge(node_dict[node1], axis1, edge.name,
+                                         node_dict[node2], axis2)
+      new_edge.set_signature(edge.signature)
+    else:
+      new_edge = Edge(node_dict[node1], axis1, edge.name)
+
+    node_dict[node1].add_edge(new_edge, axis1)
+    if not edge.is_dangling():
+      node_dict[node2].add_edge(new_edge, axis2)
+    edge_dict[edge] = new_edge
+  return node_dict, edge_dict
+
+def remove_node(node: BaseNode
+               ) -> Tuple[Dict[Text, Edge], Dict[int, Edge]]:
+  """Remove a node from the network.
+
+  Args:
+    node: The node to be removed.
+
+  Returns:
+    broken_edges_by_name: A Dictionary mapping `node`'s axis names to
+      the newly broken edges.
+    broken_edges_by_axis: A Dictionary mapping `node`'s axis numbers
+      to the newly broken edges.
+
+  Raises:
+    ValueError: If the node isn't in the network.
+  """
+  broken_edges_by_name = {}
+  broken_edges_by_axis = {}
+  for i, name in enumerate(node.axis_names):
+    if not node[i].is_dangling() and not node[i].is_trace():
+      edge1, edge2 = disconnect(node[i])
+      new_broken_edge = edge1 if edge1.node1 is not node else edge2
+      broken_edges_by_axis[i] = new_broken_edge
+      broken_edges_by_name[name] = new_broken_edge
+  node.disable()
+  return broken_edges_by_name, broken_edges_by_axis
 
 def split_node(
     node: BaseNode,

--- a/tensornetwork/tests/network_test.py
+++ b/tensornetwork/tests/network_test.py
@@ -84,7 +84,7 @@ def test_tnwork_copy_identities(backend):
 def test_connect_axis_names(backend):
   a = tn.Node(np.ones((3,)), name="a", axis_names=["one"], backend=backend)
   b = tn.Node(np.ones((3,)), name="b", axis_names=["one"], backend=backend)
-  edge = tn.connect(a["one"], b["one"])
+  tn.connect(a["one"], b["one"])
   assert a.edges == b.edges
 
 
@@ -155,7 +155,7 @@ def test_contract_edge_twice_value_error(backend):
 
 
 def test_contract_dangling_edge_value_error(backend):
-  a = tn.Node(np.array([1.0]))
+  a = tn.Node(np.array([1.0]), backend=backend)
   e = a[0]
   with pytest.raises(ValueError):
     tn.contract(e)
@@ -398,7 +398,7 @@ def test_contract_parallel(backend):
   a = tn.Node(np.eye(2), backend=backend)
   b = tn.Node(np.eye(2), backend=backend)
   edge1 = tn.connect(a[0], b[0])
-  edge2 = tn.connect(a[1], b[1])
+  tn.connect(a[1], b[1])
   c = tn.contract_parallel(edge1)
   np.testing.assert_allclose(c.tensor, 2.0)
 

--- a/tensornetwork/tests/network_test.py
+++ b/tensornetwork/tests/network_test.py
@@ -35,7 +35,7 @@ def test_tnwork_copy_conj(backend):
   if backend == "pytorch":
     pytest.skip("Pytorch does not support complex numbers")
   a = tn.Node(np.array([1.0 + 2.0j, 2.0 - 1.0j]))
-  nodes, _ = tn.copy({a}, conj=True)
+  nodes, _ = tn.copy({a}, conjugate=True)
   np.testing.assert_allclose(nodes[a].tensor, np.array([1.0 - 2.0j,
                                                         2.0 + 1.0j]))
 

--- a/tensornetwork/tests/network_test.py
+++ b/tensornetwork/tests/network_test.py
@@ -1,4 +1,3 @@
-# Copyright 2019 The TensorNetwork Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +14,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-import tensornetwork
+import tensornetwork as tn
 import pytest
 import numpy as np
 import tensorflow as tf
@@ -32,576 +31,322 @@ jax_dtypes = [
 ]
 
 
-@pytest.mark.parametrize("backend, dtype", [
-    *list(zip(['numpy'] * len(np_dtypes), np_dtypes)),
-    *list(zip(['tensorflow'] * len(tf_dtypes), tf_dtypes)),
-    *list(zip(['pytorch'] * len(torch_dtypes), torch_dtypes)),
-    *list(zip(['jax'] * len(jax_dtypes), jax_dtypes)),
-])
-def test_network_init(backend, dtype):
-  net = tensornetwork.TensorNetwork(backend=backend, dtype=dtype)
-  assert net.nodes_set == set()
-  assert net.dtype == dtype
-  assert net.node_increment == 0
-  assert net.edge_increment == 0
-
-
-def test_network_init_no_dtype(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  assert net.dtype is None
-
-
-def test_new_edge_name(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  net.edge_increment = 7
-  assert net._new_edge_name(None) == "__Edge_8"
-  assert net._new_edge_name("new_name") == "new_name"
-  assert net._new_edge_name(None) == "__Edge_10"
-
-
-def test_new_node_name(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  net.node_increment = 7
-  assert net._new_node_name(None) == "__Node_8"
-  assert net._new_node_name("new_name") == "new_name"
-  assert net._new_node_name(None) == "__Node_10"
-
-
-def test_dtype(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  assert net.dtype is None
-
-
-def test_network_copy_conj(backend):
+def test_tnwork_copy_conj(backend):
   if backend == "pytorch":
     pytest.skip("Pytorch does not support complex numbers")
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([1.0 + 2.0j, 2.0 - 1.0j]))
-  _, nodes, _ = net.copy(conj=True)
+  a = tn.Node(np.array([1.0 + 2.0j, 2.0 - 1.0j]))
+  nodes, _ = tn.copy({a}, conj=True)
   np.testing.assert_allclose(nodes[a].tensor, np.array([1.0 - 2.0j,
                                                         2.0 + 1.0j]))
 
 
-def test_network_copy(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.random.rand(3, 3, 3))
-  b = net.add_node(np.random.rand(3, 3, 3))
-  c = net.add_node(np.random.rand(3, 3, 3))
+def test_tnwork_copy(backend):
+  a = tn.Node(np.random.rand(3, 3, 3), backend=backend)
+  b = tn.Node(np.random.rand(3, 3, 3), backend=backend)
+  c = tn.Node(np.random.rand(3, 3, 3), backend=backend)
   a[0] ^ b[1]
   a[1] ^ c[2]
   b[2] ^ c[0]
-  net_copy, node_dict, _ = net.copy()
-  net_copy.check_correct()
+  node_dict, _ = tn.copy({a, b, c})
+  tn.check_correct({node_dict[n] for n in {a, b, c}})
 
   res = a @ b @ c
   res_copy = node_dict[a] @ node_dict[b] @ node_dict[c]
   np.testing.assert_allclose(res.tensor, res_copy.tensor)
 
 
-def test_network_copy_names(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.random.rand(3, 3, 3), name='a')
-  b = net.add_node(np.random.rand(3, 3, 3), name='b')
-  c = net.add_node(np.random.rand(3, 3, 3), name='c')
+def test_tnwork_copy_names(backend):
+  a = tn.Node(np.random.rand(3, 3, 3), name='a', backend=backend)
+  b = tn.Node(np.random.rand(3, 3, 3), name='b', backend=backend)
+  c = tn.Node(np.random.rand(3, 3, 3), name='c', backend=backend)
   a[0] ^ b[1]
   b[2] ^ c[0]
-  _, node_dict, edge_dict = net.copy()
-  for node in net.nodes_set:
+  node_dict, edge_dict = tn.copy({a, b, c})
+  for node in {a, b, c}:
     assert node_dict[node].name == node.name
-  for edge in net.get_all_edges():
+  for edge in tn.get_all_edges({a, b, c}):
     assert edge_dict[edge].name == edge.name
 
 
-def test_network_copy_identities(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.random.rand(3, 3, 3), name='a')
-  b = net.add_node(np.random.rand(3, 3, 3), name='b')
-  c = net.add_node(np.random.rand(3, 3, 3), name='c')
+def test_tnwork_copy_identities(backend):
+  a = tn.Node(np.random.rand(3, 3, 3), name='a', backend=backend)
+  b = tn.Node(np.random.rand(3, 3, 3), name='b', backend=backend)
+  c = tn.Node(np.random.rand(3, 3, 3), name='c', backend=backend)
   a[0] ^ b[1]
   b[2] ^ c[0]
-  _, node_dict, edge_dict = net.copy()
-  for node in net.nodes_set:
+  node_dict, edge_dict = tn.copy({a, b, c})
+  for node in {a, b, c}:
     assert not node_dict[node] is node
-  for edge in net.get_all_edges():
+  for edge in tn.get_all_edges({a, b, c}):
     assert not edge_dict[edge] is edge
 
 
-def test_add_subnetwork(backend):
-  net1 = tensornetwork.TensorNetwork(backend=backend)
-  net2 = tensornetwork.TensorNetwork(backend=backend)
-  a = net1.add_node(np.eye(2) * 2)
-  b = net1.add_node(np.eye(2) * 3)
-  e1 = net1.connect(a[0], b[0])
-  c = net2.add_node(np.eye(2) * 4)
-  net2.add_subnetwork(net1)
-  assert a in net2
-  assert b in net2
-  assert c in net2
-  assert a.network is net2
-  assert b.network is net2
-  assert c.network is net2
-  e2 = net2.connect(c[0], a[1])
-  e3 = net2.connect(c[1], b[1])
-  net2.check_correct()
-  for edge in [e1, e2, e3]:
-    net2.contract(edge)
-  result = net2.get_final_node()
-  np.testing.assert_allclose(result.tensor, 48.0)
-
-
-def test_add_subnetwork_incompatible_backends():
-  net1 = tensornetwork.TensorNetwork(backend="numpy")
-  net2 = tensornetwork.TensorNetwork(backend="tensorflow")
-  with pytest.raises(ValueError):
-    net1.add_subnetwork(net2)
-
-
-def test_merge_networks(backend):
-  net1 = tensornetwork.TensorNetwork(backend=backend)
-  net2 = tensornetwork.TensorNetwork(backend=backend)
-  a = net1.add_node(np.eye(2) * 2)
-  b = net1.add_node(np.eye(2) * 3)
-  e1 = net1.connect(a[0], b[0])
-  c = net2.add_node(np.eye(2) * 4)
-  net3 = tensornetwork.TensorNetwork.merge_networks([net1, net2])
-  assert a in net3
-  assert b in net3
-  assert c in net3
-  assert a.network is net3
-  assert b.network is net3
-  assert c.network is net3
-  e2 = net3.connect(c[0], a[1])
-  e3 = net3.connect(c[1], b[1])
-  net3.check_correct()
-  for edge in [e1, e2, e3]:
-    net3.contract(edge)
-  result = net3.get_final_node()
-  np.testing.assert_allclose(result.tensor, 48.0)
-
-
-def test_merge_networks_incompatible_backends():
-  net1 = tensornetwork.TensorNetwork(backend="numpy")
-  net2 = tensornetwork.TensorNetwork(backend="tensorflow")
-  with pytest.raises(ValueError):
-    tensornetwork.TensorNetwork.merge_networks([net1, net2])
-
-
-def test_switch_backend_to_tensorflow():
-  net = tensornetwork.TensorNetwork(backend="numpy")
-  a = net.add_node(np.eye(2))
-  net.switch_backend(new_backend="tensorflow")
-  assert isinstance(a.tensor, tf.Tensor)
-
-
-def test_add_node_sanity_check(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  net.add_node(np.eye(2), "a")
-  net.check_correct()
-
-
-def test_add_node_in_network(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  assert a in net
-
-
-def test_add_node_twice_raise_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(tensornetwork.CopyNode(3, 3, backend=backend))
-  with pytest.raises(ValueError):
-    net.add_node(a)
-
-
-def test_add_copy_node(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(
-      tensornetwork.CopyNode(
-          3, 3, name="TestName", axis_names=['a', 'b', 'c'], backend=backend))
-  assert a in net
-
-
-def test_connect_dangling_edges(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((3,)))
-  b = net.add_node(np.ones((3,)))
-  edge = net.connect(a[0], b[0])
-  net.check_correct()
-  assert a.edges == b.edges
-  assert edge in net
-
-
 def test_connect_axis_names(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((3,)), name="a", axis_names=["one"])
-  b = net.add_node(np.ones((3,)), name="b", axis_names=["one"])
-  edge = net.connect(a["one"], b["one"])
-  net.check_correct()
+  a = tn.Node(np.ones((3,)), name="a", axis_names=["one"], backend=backend)
+  b = tn.Node(np.ones((3,)), name="b", axis_names=["one"], backend=backend)
+  edge = tn.connect(a["one"], b["one"])
   assert a.edges == b.edges
-  assert edge in net
 
 
 def test_connect_twice_edge_axis_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([2.]), name="a")
-  b = net.add_node(np.array([2.]), name="b")
-  net.connect(a[0], b[0])
+  a = tn.Node(np.array([2.]), name="a", backend=backend)
+  b = tn.Node(np.array([2.]), name="b", backend=backend)
+  tn.connect(a[0], b[0])
   with pytest.raises(ValueError):
-    net.connect(a[0], b[0])
+    tn.connect(a[0], b[0])
 
 
 def test_connect_same_edge_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
+  a = tn.Node(np.eye(2), backend=backend)
   with pytest.raises(ValueError):
-    net.connect(a[0], a[0])
+    tn.connect(a[0], a[0])
 
 
 def test_disconnect_edge(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([1.0] * 5), "a")
-  b = net.add_node(np.array([1.0] * 5), "b")
-  e = net.connect(a[0], b[0])
+  a = tn.Node(np.array([1.0] * 5), "a", backend=backend)
+  b = tn.Node(np.array([1.0] * 5), "b", backend=backend)
+  e = tn.connect(a[0], b[0])
   assert not e.is_dangling()
-  dangling_edge_1, dangling_edge_2 = net.disconnect(e)
-  net.check_correct(check_connections=False)
+  dangling_edge_1, dangling_edge_2 = tn.disconnect(e)
   assert dangling_edge_1.is_dangling()
   assert dangling_edge_2.is_dangling()
   assert a.get_edge(0) == dangling_edge_1
   assert b.get_edge(0) == dangling_edge_2
 
 
-def test_disconnect_edge_not_in_network(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  edge = net.connect(a[0], b[0])
-  net.disconnect(edge)
-  assert edge not in net
-
-
 def test_disconnect_dangling_edge_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
+  a = tn.Node(np.eye(2), backend=backend)
   with pytest.raises(ValueError):
-    net.disconnect(a[0])
+    tn.disconnect(a[0])
 
 
 def test_contract_trace_single_node(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones([10, 10]), name="a")
-  edge = net.connect(a[0], a[1], "edge")
-  net.check_correct()
-  result = net._contract_trace(edge)
-  net.check_correct()
+  a = tn.Node(np.ones([10, 10]), name="a", backend=backend)
+  edge = tn.connect(a[0], a[1], "edge")
+  result = tn.contract(edge)
   np.testing.assert_allclose(result.tensor, 10.0)
 
 
-def test_contract_trace_different_nodes_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([2.]))
-  b = net.add_node(np.array([2.]))
-  e = net.connect(a[0], b[0])
-  with pytest.raises(ValueError):
-    net._contract_trace(e)
-
-
-def test_contract_trace_dangling_edge_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([1.0]))
-  e = a[0]
-  with pytest.raises(ValueError):
-    net._contract_trace(e)
-
-
 def test_contract_single_edge(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([1.0] * 5), "a")
-  b = net.add_node(np.array([1.0] * 5), "b")
-  e = net.connect(a[0], b[0])
-  c = net.contract(e)
-  net.check_correct()
+  a = tn.Node(np.array([1.0] * 5), "a", backend=backend)
+  b = tn.Node(np.array([1.0] * 5), "b", backend=backend)
+  e = tn.connect(a[0], b[0])
+  c = tn.contract(e)
+  tn.check_correct({c})
   val = c.tensor
   np.testing.assert_allclose(val, 5.0)
 
 
 def test_contract_name_contracted_node(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  node = net.add_node(np.eye(2), name="Identity Matrix")
+  node = tn.Node(np.eye(2), name="Identity Matrix", backend=backend)
   assert node.name == "Identity Matrix"
-  edge = net.connect(node[0], node[1], name="Trace Edge")
+  edge = tn.connect(node[0], node[1], name="Trace Edge")
   assert edge.name == "Trace Edge"
-  final_result = net.contract(edge, name="Trace Of Identity")
+  final_result = tn.contract(edge, name="Trace Of Identity")
   assert final_result.name == "Trace Of Identity"
 
 
 def test_contract_edge_twice_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  e = net.connect(a[0], a[1], name="edge")
-  net.contract(e)
+  a = tn.Node(np.eye(2), backend=backend)
+  e = tn.connect(a[0], a[1], name="edge")
+  tn.contract(e)
   with pytest.raises(ValueError):
-    net.contract(e)
+    tn.contract(e)
 
 
 def test_contract_dangling_edge_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([1.0]))
+  a = tn.Node(np.array([1.0]))
   e = a[0]
   with pytest.raises(ValueError):
-    net.contract(e)
+    tn.contract(e)
 
 
 def test_contract_copy_node(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([1, 2, 3], dtype=np.float64))
-  b = net.add_node(np.array([10, 20, 30], dtype=np.float64))
-  c = net.add_node(np.array([5, 6, 7], dtype=np.float64))
-  d = net.add_node(np.array([1, -1, 1], dtype=np.float64))
-  cn = net.add_copy_node(rank=4, dimension=3)
-  net.connect(a[0], cn[0])
-  net.connect(b[0], cn[1])
-  net.connect(c[0], cn[2])
-  net.connect(d[0], cn[3])
+  a = tn.Node(np.array([1, 2, 3]), backend=backend)
+  b = tn.Node(np.array([10, 20, 30]), backend=backend)
+  c = tn.Node(np.array([5, 6, 7]), backend=backend)
+  d = tn.Node(np.array([1, -1, 1]), backend=backend)
+  cn = tn.CopyNode(rank=4, dimension=3, backend=backend)
+  tn.connect(a[0], cn[0])
+  tn.connect(b[0], cn[1])
+  tn.connect(c[0], cn[2])
+  tn.connect(d[0], cn[3])
 
-  net.contract_copy_node(cn)
-  val = net.get_final_node()
+  val = tn.contract_copy_node(cn)
   result = val.tensor
   assert list(result.shape) == []
   np.testing.assert_allclose(result, 50 - 240 + 630)
 
 
 def test_contract_copy_node_dangling_edge_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([1, 2, 3], dtype=np.float64))
-  b = net.add_node(np.array([10, 20, 30], dtype=np.float64))
-  c = net.add_node(np.array([5, 6, 7], dtype=np.float64))
-  cn = net.add_copy_node(rank=4, dimension=3)
-  net.connect(a[0], cn[0])
-  net.connect(b[0], cn[1])
-  net.connect(c[0], cn[2])
+  a = tn.Node(np.array([1, 2, 3]), backend=backend)
+  b = tn.Node(np.array([10, 20, 30]), backend=backend)
+  c = tn.Node(np.array([5, 6, 7]), backend=backend)
+  cn = tn.CopyNode(rank=4, dimension=3, backend=backend)
+  tn.connect(a[0], cn[0])
+  tn.connect(b[0], cn[1])
+  tn.connect(c[0], cn[2])
 
   with pytest.raises(ValueError):
-    net.contract_copy_node(cn)
+    tn.contract_copy_node(cn)
 
 
 def test_outer_product(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 4, 5)), name="A")
-  b = net.add_node(np.ones((4, 3, 6)), name="B")
-  c = net.add_node(np.ones((3, 2)), name="C")
-  net.connect(a[1], b[0])
-  net.connect(a[0], c[1])
-  net.connect(b[1], c[0])
+  a = tn.Node(np.ones((2, 4, 5)), name="A", backend=backend)
+  b = tn.Node(np.ones((4, 3, 6)), name="B", backend=backend)
+  c = tn.Node(np.ones((3, 2)), name="C", backend=backend)
+  tn.connect(a[1], b[0])
+  tn.connect(a[0], c[1])
+  tn.connect(b[1], c[0])
   # Purposely leave b's 3rd axis undefined.
-  d = net.outer_product(a, b, name="D")
-  net.check_correct()
+  d = tn.outer_product(a, b, name="D")
+  tn.check_correct({c, d})
   assert d.shape == (2, 4, 5, 4, 3, 6)
   np.testing.assert_allclose(d.tensor, np.ones((2, 4, 5, 4, 3, 6)))
   assert d.name == "D"
 
 
-def test_get_final_node(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((3, 3)), "a")
-  b = net.add_node(np.ones((3, 3)), "b")
-  e1 = net.connect(a[0], b[0])
-  e2 = net.connect(a[1], b[1])
-  net.contract(e1)
-  expected = net.contract(e2)
-  assert net.get_final_node() == expected
-
-
-def test_get_final_node_dangling_edge_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((3, 3)), "a")
-  net.connect(a[0], a[1])
-  with pytest.raises(ValueError):
-    net.get_final_node()
-
-
-def test_get_final_node_two_nodes_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((3, 3)), "a")
-  b = net.add_node(np.ones((3, 3)), "b")
-  net.connect(a[0], b[0])
-  net.connect(a[1], b[1])
-  with pytest.raises(ValueError):
-    net.get_final_node()
-
-
 def test_get_all_nondangling(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  edge1 = net.connect(a[0], b[0])
-  c = net.add_node(np.eye(2))
-  d = net.add_node(np.eye(2))
-  edge2 = net.connect(c[0], d[0])
-  edge3 = net.connect(a[1], c[1])
-  assert {edge1, edge2, edge3} == net.get_all_nondangling()
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  edge1 = tn.connect(a[0], b[0])
+  c = tn.Node(np.eye(2), backend=backend)
+  d = tn.Node(np.eye(2), backend=backend)
+  edge2 = tn.connect(c[0], d[0])
+  edge3 = tn.connect(a[1], c[1])
+  assert {edge1, edge2, edge3} == tn.get_all_nondangling({a, b, c, d})
 
 
 def test_get_all_edges(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  assert {a[0], a[1], b[0], b[1]} == net.get_all_edges()
-
-
-def test_outer_product_final_nodes(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  edges = []
-  for i in range(1, 5):
-    edges.append(net.add_node(np.ones(i))[0])
-  final_node = net.outer_product_final_nodes(edges)
-  np.testing.assert_allclose(final_node.tensor, np.ones([1, 2, 3, 4]))
-  assert final_node.get_all_edges() == edges
-
-
-def test_outer_product_final_nodes_not_contracted_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones(2))
-  b = net.add_node(np.ones(2))
-  e = net.connect(a[0], b[0])
-  with pytest.raises(ValueError):
-    net.outer_product_final_nodes([e])
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  assert {a[0], a[1], b[0], b[1]} == tn.get_all_edges({a, b})
 
 
 def test_check_connected_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([2, 2.]))
-  b = net.add_node(np.array([2, 2.]))
-  net.connect(a[0], b[0])
-  c = net.add_node(np.array([2, 2.]))
-  d = net.add_node(np.array([2, 2.]))
-  net.connect(c[0], d[0])
+  a = tn.Node(np.array([2, 2.]), backend=backend)
+  b = tn.Node(np.array([2, 2.]), backend=backend)
+  tn.connect(a[0], b[0])
+  c = tn.Node(np.array([2, 2.]), backend=backend)
+  d = tn.Node(np.array([2, 2.]), backend=backend)
+  tn.connect(c[0], d[0])
   with pytest.raises(ValueError):
-    net.check_connected()
+    tn.check_connected({a, b, c, d})
 
 
 def test_flatten_trace_edges(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 3, 4, 3, 5, 5)))
-  c = net.add_node(np.zeros((2, 4)))
-  e1 = net.connect(a[1], a[3])
-  e2 = net.connect(a[4], a[5])
-  external_1 = net.connect(a[0], c[0])
-  external_2 = net.connect(c[1], a[2])
-  new_edge = net.flatten_edges([e1, e2], "New Edge")
-  net.check_correct()
+  a = tn.Node(np.zeros((2, 3, 4, 3, 5, 5)), backend=backend)
+  c = tn.Node(np.zeros((2, 4)), backend=backend)
+  e1 = tn.connect(a[1], a[3])
+  e2 = tn.connect(a[4], a[5])
+  external_1 = tn.connect(a[0], c[0])
+  external_2 = tn.connect(c[1], a[2])
+  new_edge = tn.flatten_edges([e1, e2], "New Edge")
+  tn.check_correct({a, c})
   assert a.shape == (2, 4, 15, 15)
   assert a.edges == [external_1, external_2, new_edge, new_edge]
   assert new_edge.name == "New Edge"
 
 
 def test_flatten_edges_standard(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 3, 5)), name="A")
-  b = net.add_node(np.zeros((2, 3, 4, 5)), name="B")
-  e1 = net.connect(a[0], b[0], "Edge_1_1")
-  e2 = net.connect(a[2], b[3], "Edge_2_3")
+  a = tn.Node(np.zeros((2, 3, 5)), name="A", backend=backend)
+  b = tn.Node(np.zeros((2, 3, 4, 5)), name="B", backend=backend)
+  e1 = tn.connect(a[0], b[0], "Edge_1_1")
+  e2 = tn.connect(a[2], b[3], "Edge_2_3")
   edge_a_1 = a[1]
   edge_b_1 = b[1]
   edge_b_2 = b[2]
-  new_edge = net.flatten_edges([e1, e2], new_edge_name="New Edge")
+  new_edge = tn.flatten_edges([e1, e2], new_edge_name="New Edge")
   assert a.shape == (3, 10)
   assert b.shape == (3, 4, 10)
   assert a.edges == [edge_a_1, new_edge]
   assert b.edges == [edge_b_1, edge_b_2, new_edge]
-  net.check_correct()
+  tn.check_correct({a, b})
 
 
 def test_flatten_edges_dangling(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 3, 4, 5)), name="A")
+  a = tn.Node(np.zeros((2, 3, 4, 5)), name="A", backend=backend)
   e1 = a[0]
   e2 = a[1]
   e3 = a[2]
   e4 = a[3]
-  flattened_edge = net.flatten_edges([e1, e3], new_edge_name="New Edge")
+  flattened_edge = tn.flatten_edges([e1, e3], new_edge_name="New Edge")
   assert a.shape == (3, 5, 8)
   assert a.edges == [e2, e4, flattened_edge]
   assert flattened_edge.name == "New Edge"
-  net.check_correct()
+  tn.check_correct({a})
 
 
 def test_flatten_edges_empty_list_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  net.connect(a[0], b[0])
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  tn.connect(a[0], b[0])
   with pytest.raises(ValueError):
-    net.flatten_edges([])
+    tn.flatten_edges([])
 
 
 def test_flatten_edges_different_nodes_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  c = net.add_node(np.eye(2))
-  e1 = net.connect(a[0], b[0])
-  e2 = net.connect(a[1], c[0])
-  net.connect(b[1], c[1])
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  c = tn.Node(np.eye(2), backend=backend)
+  e1 = tn.connect(a[0], b[0])
+  e2 = tn.connect(a[1], c[0])
+  tn.connect(b[1], c[1])
   with pytest.raises(ValueError):
-    net.flatten_edges([e1, e2])
+    tn.flatten_edges([e1, e2])
 
 
 def test_get_shared_edges(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2, 2)))
-  b = net.add_node(np.ones((2, 2, 2)))
-  c = net.add_node(np.ones((2, 2, 2)))
-  e1 = net.connect(a[0], b[0])
-  e2 = net.connect(b[1], c[1])
-  e3 = net.connect(a[2], b[2])
-  assert net.get_shared_edges(a, b) == {e1, e3}
-  assert net.get_shared_edges(b, c) == {e2}
+  a = tn.Node(np.ones((2, 2, 2)), backend=backend)
+  b = tn.Node(np.ones((2, 2, 2)), backend=backend)
+  c = tn.Node(np.ones((2, 2, 2)), backend=backend)
+  e1 = tn.connect(a[0], b[0])
+  e2 = tn.connect(b[1], c[1])
+  e3 = tn.connect(a[2], b[2])
+  assert tn.get_shared_edges(a, b) == {e1, e3}
+  assert tn.get_shared_edges(b, c) == {e2}
 
 
 def test_get_parallel_edge(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2,) * 5))
-  b = net.add_node(np.ones((2,) * 5))
+  a = tn.Node(np.ones((2,) * 5), backend=backend)
+  b = tn.Node(np.ones((2,) * 5), backend=backend)
   edges = set()
   for i in {0, 1, 3}:
-    edges.add(net.connect(a[i], b[i]))
+    edges.add(tn.connect(a[i], b[i]))
   # sort by edge signature
-  a = sorted(list(edges))[0]
-  assert net.get_parallel_edges(a) == edges
+  e = sorted(list(edges))[0]
+  assert tn.get_parallel_edges(e) == edges
 
 
 def test_flatten_edges_between(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((3, 4, 5)))
-  b = net.add_node(np.ones((5, 4, 3)))
-  net.connect(a[0], b[2])
-  net.connect(a[1], b[1])
-  net.connect(a[2], b[0])
-  net.flatten_edges_between(a, b)
-  net.check_correct()
+  a = tn.Node(np.ones((3, 4, 5)), backend=backend)
+  b = tn.Node(np.ones((5, 4, 3)), backend=backend)
+  tn.connect(a[0], b[2])
+  tn.connect(a[1], b[1])
+  tn.connect(a[2], b[0])
+  tn.flatten_edges_between(a, b)
+  tn.check_correct({a, b})
   np.testing.assert_allclose(a.tensor, np.ones((60,)))
   np.testing.assert_allclose(b.tensor, np.ones((60,)))
 
 
 def test_flatten_edges_between_no_edges(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((3)))
-  b = net.add_node(np.ones((3)))
-  assert net.flatten_edges_between(a, b) is None
+  a = tn.Node(np.ones((3)), backend=backend)
+  b = tn.Node(np.ones((3)), backend=backend)
+  assert tn.flatten_edges_between(a, b) is None
 
 
 def test_flatten_all_edges(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((3, 3, 5, 6, 2, 2)))
-  b = net.add_node(np.ones((5, 6, 7)))
-  c = net.add_node(np.ones((7,)))
-  trace_edge1 = net.connect(a[0], a[1])
-  trace_edge2 = net.connect(a[4], a[5])
-  split_edge1 = net.connect(a[2], b[0])
-  split_edge2 = net.connect(a[3], b[1])
-  ok_edge = net.connect(b[2], c[0])
-  flat_edges = net.flatten_all_edges()
-  net.check_correct()
+  a = tn.Node(np.ones((3, 3, 5, 6, 2, 2)), backend=backend)
+  b = tn.Node(np.ones((5, 6, 7)), backend=backend)
+  c = tn.Node(np.ones((7,)), backend=backend)
+  trace_edge1 = tn.connect(a[0], a[1])
+  trace_edge2 = tn.connect(a[4], a[5])
+  split_edge1 = tn.connect(a[2], b[0])
+  split_edge2 = tn.connect(a[3], b[1])
+  ok_edge = tn.connect(b[2], c[0])
+  flat_edges = tn.flatten_all_edges({a, b, c})
+  tn.check_correct({a, b, c})
   assert len(flat_edges) == 3
   assert trace_edge1 not in flat_edges
   assert trace_edge2 not in flat_edges
@@ -611,19 +356,18 @@ def test_flatten_all_edges(backend):
 
 
 def test_contract_between(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((2, 3, 4, 5))
   b_val = np.ones((3, 5, 4, 2))
-  a = net.add_node(a_val)
-  b = net.add_node(b_val)
-  net.connect(a[0], b[3])
-  net.connect(b[1], a[3])
-  net.connect(a[1], b[0])
+  a = tn.Node(a_val, backend=backend)
+  b = tn.Node(b_val, backend=backend)
+  tn.connect(a[0], b[3])
+  tn.connect(b[1], a[3])
+  tn.connect(a[1], b[0])
   edge_a = a[2]
   edge_b = b[2]
-  c = net.contract_between(a, b, name="New Node")
+  c = tn.contract_between(a, b, name="New Node")
   c.reorder_edges([edge_a, edge_b])
-  net.check_correct()
+  tn.check_correct({c})
   # Check expected values.
   a_flat = np.reshape(np.transpose(a_val, (2, 1, 0, 3)), (4, 30))
   b_flat = np.reshape(np.transpose(b_val, (2, 0, 3, 1)), (4, 30))
@@ -633,49 +377,36 @@ def test_contract_between(backend):
 
 
 def test_contract_between_no_outer_product_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((2, 3, 4))
   b_val = np.ones((5, 6, 7))
-  a = net.add_node(a_val)
-  b = net.add_node(b_val)
+  a = tn.Node(a_val, backend=backend)
+  b = tn.Node(b_val, backend=backend)
   with pytest.raises(ValueError):
-    net.contract_between(a, b)
+    tn.contract_between(a, b)
 
 
 def test_contract_between_outer_product_no_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((2, 3, 4))
   b_val = np.ones((5, 6, 7))
-  a = net.add_node(a_val)
-  b = net.add_node(b_val)
-  c = net.contract_between(a, b, allow_outer_product=True)
+  a = tn.Node(a_val, backend=backend)
+  b = tn.Node(b_val, backend=backend)
+  c = tn.contract_between(a, b, allow_outer_product=True)
   assert c.shape == (2, 3, 4, 5, 6, 7)
 
 
 def test_contract_parallel(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  edge1 = net.connect(a[0], b[0])
-  edge2 = net.connect(a[1], b[1])
-  c = net.contract_parallel(edge1)
-  assert edge2 not in net
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  edge1 = tn.connect(a[0], b[0])
+  edge2 = tn.connect(a[1], b[1])
+  c = tn.contract_parallel(edge1)
   np.testing.assert_allclose(c.tensor, 2.0)
 
 
 def test_remove_node(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  net.connect(a[0], b[0])
-  broken_edges_by_name, broken_edges_by_axis = net.remove_node(b)
-  assert broken_edges_by_name == {"__Edge_3": a[0]}
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  tn.connect(a[0], b[0])
+  broken_edges_by_name, broken_edges_by_axis = tn.remove_node(b)
+  assert broken_edges_by_name == {"0": a[0]}
   assert broken_edges_by_axis == {0: a[0]}
-
-
-def test_remove_node_value_error(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  net2 = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2, 2)))
-  with pytest.raises(ValueError):
-    net2.remove_node(a)

--- a/tensornetwork/tests/tensornetwork_test.py
+++ b/tensornetwork/tests/tensornetwork_test.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-import tensornetwork
+import tensornetwork as tn
 import pytest
 import numpy as np
 import tensorflow as tf
@@ -32,17 +32,16 @@ jax_dtypes = [
 
 
 def test_network_copy_reordered(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.random.rand(3, 3, 3))
-  b = net.add_node(np.random.rand(3, 3, 3))
-  c = net.add_node(np.random.rand(3, 3, 3))
+  a = tn.Node(np.random.rand(3, 3, 3), backend=backend)
+  b = tn.Node(np.random.rand(3, 3, 3), backend=backend)
+  c = tn.Node(np.random.rand(3, 3, 3), backend=backend)
   a[0] ^ b[1]
   a[1] ^ c[2]
   b[2] ^ c[0]
 
   edge_order = [a[2], c[1], b[0]]
-  net_copy, node_dict, edge_dict = net.copy()
-  net_copy.check_correct()
+  node_dict, edge_dict = tn.copy({a, b, c})
+  tn.check_correct({a, b, c})
 
   res = a @ b @ c
   res.reorder_edges(edge_order)
@@ -52,93 +51,82 @@ def test_network_copy_reordered(backend):
 
 
 def test_add_node_names(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2), "a", axis_names=["e0", "e1"])
+  a = tn.Node(np.eye(2), "a", axis_names=["e0", "e1"], backend=backend)
   assert a.name == "a"
   assert a[0].name == "e0"
   assert a[1].name == "e1"
 
 
 def test_add_copy_node_from_node_object(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(
-      tensornetwork.CopyNode(
-          3, 3, name="TestName", axis_names=['a', 'b', 'c'], backend=backend))
-  assert a in net
+  a = tn.CopyNode(
+          3, 3, name="TestName", axis_names=['a', 'b', 'c'], backend=backend)
   assert a.shape == (3, 3, 3)
-  assert isinstance(a, tensornetwork.CopyNode)
+  assert isinstance(a, tn.CopyNode)
   assert a.name == "TestName"
   assert a.axis_names == ['a', 'b', 'c']
-  b = net.add_node(np.eye(3))
+  b = tn.Node(np.eye(3), backend=backend)
   e = a[0] ^ b[0]
-  c = net.contract(e)
+  c = tn.contract(e)
   np.testing.assert_allclose(c.tensor, a.tensor)
 
 
 def test_default_names_add_node_object(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(tensornetwork.CopyNode(3, 3, backend=backend))
+  a = tn.CopyNode(3, 3, backend=backend)
   assert a.name is not None
   assert len(a.axis_names) == 3
 
 
 def test_set_tensor(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones(2))
+  a = tn.Node(np.ones(2), backend=backend)
   np.testing.assert_allclose(a.tensor, np.ones(2))
   a.tensor = np.zeros(2)
   np.testing.assert_allclose(a.tensor, np.zeros(2))
 
 
 def test_has_nondangling_edge(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones(2))
+  a = tn.Node(np.ones(2), backend=backend)
   assert not a.has_nondangling_edge()
-  b = net.add_node(np.ones((2, 2)))
-  net.connect(b[0], b[1])
+  b = tn.Node(np.ones((2, 2)), backend=backend)
+  tn.connect(b[0], b[1])
   assert b.has_nondangling_edge()
 
 
 def test_large_nodes(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros([5, 6, 7, 8, 9]), "a")
-  b = net.add_node(np.zeros([5, 6, 7, 8, 9]), "b")
+  a = tn.Node(np.zeros([5, 6, 7, 8, 9]), "a", backend=backend)
+  b = tn.Node(np.zeros([5, 6, 7, 8, 9]), "b", backend=backend)
   for i in range(5):
-    net.connect(a[i], b[i])
-  net.check_correct()
+    tn.connect(a[i], b[i])
+  tn.check_correct({a, b})
 
 
 def test_small_matmul(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros([10, 10]), name="a")
-  b = net.add_node(np.zeros([10, 10]), name="b")
-  edge = net.connect(a[0], b[0], "edge")
-  net.check_correct()
-  c = net.contract(edge, name="a * b")
+  a = tn.Node(np.zeros([10, 10]), name="a", backend=backend)
+  b = tn.Node(np.zeros([10, 10]), name="b", backend=backend)
+  edge = tn.connect(a[0], b[0], "edge")
+  tn.check_correct({a, b})
+  c = tn.contract(edge, name="a * b")
   assert list(c.shape) == [10, 10]
-  net.check_correct()
+  tn.check_correct({c})
 
 
 def test_double_trace(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones([10, 10, 10, 10]), name="a")
-  edge1 = net.connect(a[0], a[1], "edge1")
-  edge2 = net.connect(a[2], a[3], "edge2")
-  net.check_correct()
-  net._contract_trace(edge1)
-  net.check_correct()
-  val = net._contract_trace(edge2)
-  net.check_correct()
+  a = tn.Node(np.ones([10, 10, 10, 10]), name="a", backend=backend)
+  edge1 = tn.connect(a[0], a[1], "edge1")
+  edge2 = tn.connect(a[2], a[3], "edge2")
+  tn.check_correct({a})
+  val = tn.contract(edge1)
+  tn.check_correct({val})
+  val = tn.contract(edge2)
+  tn.check_correct({val})
   np.testing.assert_allclose(val.tensor, 100.0)
 
 
 def test_indirect_trace(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones([10, 10]), name="a")
-  edge = net.connect(a[0], a[1], "edge")
-  net.check_correct()
-  val = net.contract(edge)
-  net.check_correct()
+  a = tn.Node(np.ones([10, 10]), name="a", backend=backend)
+  edge = tn.connect(a[0], a[1], "edge")
+  tn.check_correct({a})
+  val = tn.contract(edge)
+  tn.check_correct({val})
   np.testing.assert_allclose(val.tensor, 10.0)
 
 
@@ -151,22 +139,21 @@ def test_real_physics(backend):
   contract2 = np.tensordot(c_vals, contract1, [[0], [2]])
   final_result = np.trace(contract2, axis1=0, axis2=4)
   # Build the network
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(a_vals, name="T")
-  b = net.add_node(b_vals, name="A")
-  c = net.add_node(c_vals, name="B")
-  e1 = net.connect(a[2], b[0], "edge")
-  e2 = net.connect(c[0], a[3], "edge2")
-  e3 = net.connect(b[1], c[1], "edge3")
-  net.check_correct()
-  node_result = net.contract(e1)
+  a = tn.Node(a_vals, name="T", backend=backend)
+  b = tn.Node(b_vals, name="A", backend=backend)
+  c = tn.Node(c_vals, name="B", backend=backend)
+  e1 = tn.connect(a[2], b[0], "edge")
+  e2 = tn.connect(c[0], a[3], "edge2")
+  e3 = tn.connect(b[1], c[1], "edge3")
+  tn.check_correct(tn.reachable(a))
+  node_result = tn.contract(e1)
   np.testing.assert_allclose(node_result.tensor, contract1)
-  net.check_correct()
-  node_result = net.contract(e2)
+  tn.check_correct(tn.reachable(node_result))
+  node_result = tn.contract(e2)
   np.testing.assert_allclose(node_result.tensor, contract2)
-  net.check_correct()
-  val = net.contract(e3)
-  net.check_correct()
+  tn.check_correct(tn.reachable(node_result))
+  val = tn.contract(e3)
+  tn.check_correct(tn.reachable(val))
   np.testing.assert_allclose(val.tensor, final_result)
 
 
@@ -179,22 +166,21 @@ def test_real_physics_with_tensors(backend):
   contract2 = np.tensordot(c_vals, contract1, [[0], [2]])
   final_result = np.trace(contract2, axis1=0, axis2=4)
   # Build the network
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones([2, 3, 4, 5]), name="T")
-  b = net.add_node(np.ones([4, 6, 7]), name="A")
-  c = net.add_node(np.ones([5, 6, 8]), name="B")
-  e1 = net.connect(a[2], b[0], "edge")
-  e2 = net.connect(c[0], a[3], "edge2")
-  e3 = net.connect(b[1], c[1], "edge3")
-  net.check_correct()
-  node_result = net.contract(e1)
+  a = tn.Node(np.ones([2, 3, 4, 5]), name="T", backend=backend)
+  b = tn.Node(np.ones([4, 6, 7]), name="A", backend=backend)
+  c = tn.Node(np.ones([5, 6, 8]), name="B", backend=backend)
+  e1 = tn.connect(a[2], b[0], "edge")
+  e2 = tn.connect(c[0], a[3], "edge2")
+  e3 = tn.connect(b[1], c[1], "edge3")
+  tn.check_correct({a, b, c})
+  node_result = tn.contract(e1)
   np.testing.assert_allclose(node_result.tensor, contract1)
-  net.check_correct()
-  node_result = net.contract(e2)
+  tn.check_correct(tn.reachable(node_result))
+  node_result = tn.contract(e2)
   np.testing.assert_allclose(node_result.tensor, contract2)
-  net.check_correct()
-  val = net.contract(e3)
-  net.check_correct()
+  tn.check_correct(tn.reachable(node_result))
+  val = tn.contract(e3)
+  tn.check_correct(tn.reachable(val))
   np.testing.assert_allclose(val.tensor, final_result)
 
 
@@ -207,100 +193,89 @@ def test_real_physics_naive_contraction(backend):
   contract2 = np.tensordot(c_vals, contract1, [[0], [2]])
   final_result = np.trace(contract2, axis1=0, axis2=4)
   # Build the network
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones([2, 3, 4, 5]), name="T")
-  b = net.add_node(np.ones([4, 6, 7]), name="A")
-  c = net.add_node(np.ones([5, 6, 8]), name="B")
-  e1 = net.connect(a[2], b[0], "edge")
-  e2 = net.connect(c[0], a[3], "edge2")
-  e3 = net.connect(b[1], c[1], "edge3")
+  a = tn.Node(np.ones([2, 3, 4, 5]), name="T", backend=backend)
+  b = tn.Node(np.ones([4, 6, 7]), name="A", backend=backend)
+  c = tn.Node(np.ones([5, 6, 8]), name="B", backend=backend)
+  e1 = tn.connect(a[2], b[0], "edge")
+  e2 = tn.connect(c[0], a[3], "edge2")
+  e3 = tn.connect(b[1], c[1], "edge3")
   for edge in [e1, e2, e3]:
-    net.contract(edge)
-  val = net.get_final_node()
+    val = tn.contract(edge)
   assert list(val.shape) == [8, 2, 3, 7]
   np.testing.assert_allclose(val.tensor, final_result)
 
 
 def test_with_tensors(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2) * 2, name="T")
-  b = net.add_node(np.eye(2) * 3, name="A")
-  e1 = net.connect(a[0], b[0], "edge")
-  e2 = net.connect(a[1], b[1], "edge2")
-  net.check_correct()
-  net.contract(e1)
-  net.check_correct()
-  val = net.contract(e2)
-  net.check_correct()
+  a = tn.Node(np.eye(2) * 2, name="T", backend=backend)
+  b = tn.Node(np.eye(2) * 3, name="A", backend=backend)
+  e1 = tn.connect(a[0], b[0], "edge")
+  e2 = tn.connect(a[1], b[1], "edge2")
+  tn.check_correct({a, b})
+  result = tn.contract(e1)
+  tn.check_correct(tn.reachable(result))
+  val = tn.contract(e2)
+  tn.check_correct(tn.reachable(val))
   np.testing.assert_allclose(val.tensor, 12.0)
 
 
 def test_node2_contract_trace(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros([3, 3, 1]))
-  b = net.add_node(np.zeros([1]))
-  net.connect(b[0], a[2])
-  trace_edge = net.connect(a[0], a[1])
-  net._contract_trace(trace_edge)
-  net.check_correct()
+  a = tn.Node(np.zeros([3, 3, 1]), backend=backend)
+  b = tn.Node(np.zeros([1]), backend=backend)
+  tn.connect(b[0], a[2])
+  trace_edge = tn.connect(a[0], a[1])
+  c = tn.contract(trace_edge)
+  tn.check_correct({c})
 
 
 def test_node_get_dim_bad_axis(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  node = net.add_node(np.eye(2), name="a", axis_names=["1", "2"])
+  node = tn.Node(np.eye(2), name="a", axis_names=["1", "2"], backend=backend)
   with pytest.raises(ValueError):
     node.get_dimension(10)
 
 
 def test_named_axis(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2), axis_names=["alpha", "beta"])
-  e = net.connect(a["alpha"], a["beta"])
-  b = net.contract(e)
+  a = tn.Node(np.eye(2), axis_names=["alpha", "beta"], backend=backend)
+  e = tn.connect(a["alpha"], a["beta"])
+  b = tn.contract(e)
   np.testing.assert_allclose(b.tensor, 2.0)
 
 
 def test_mixed_named_axis(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2) * 2.0, axis_names=["alpha", "beta"])
-  b = net.add_node(np.eye(2) * 3.0)
-  e1 = net.connect(a["alpha"], b[0])
+  a = tn.Node(np.eye(2) * 2.0, axis_names=["alpha", "beta"], backend=backend)
+  b = tn.Node(np.eye(2) * 3.0, backend=backend)
+  e1 = tn.connect(a["alpha"], b[0])
   # Axes should still be indexable by numbers even with naming.
-  e2 = net.connect(a[1], b[1])
-  net.contract(e1)
-  result = net.contract(e2)
+  e2 = tn.connect(a[1], b[1])
+  tn.contract(e1)
+  result = tn.contract(e2)
   np.testing.assert_allclose(result.tensor, 12.0)
 
 
 def test_duplicate_name(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   with pytest.raises(ValueError):
-    net.add_node(np.eye(2), axis_names=["test", "test"])
+    tn.Node(np.eye(2), axis_names=["test", "test"], backend=backend)
 
 
 def test_bad_axis_name_length(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   with pytest.raises(ValueError):
     # This should have 2 names, not 1.
-    net.add_node(np.eye(2), axis_names=["need_2_names"])
+    tn.Node(np.eye(2), axis_names=["need_2_names"], backend=backend)
 
 
 def test_bad_axis_name_connect(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2), axis_names=["test", "names"])
+  a = tn.Node(np.eye(2), axis_names=["test", "names"], backend=backend)
   with pytest.raises(ValueError):
     a.get_edge("bad_name")
 
 
 def test_node_edge_ordering(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 3, 4)))
+  a = tn.Node(np.zeros((2, 3, 4)), backend=backend)
   e2 = a[0]
   e3 = a[1]
   e4 = a[2]
   assert a.shape == (2, 3, 4)
   a.reorder_edges([e4, e2, e3])
-  net.check_correct()
+  tn.check_correct({a})
   assert a.shape == (4, 2, 3)
   assert e2.axis1 == 1
   assert e3.axis1 == 2
@@ -308,43 +283,39 @@ def test_node_edge_ordering(backend):
 
 
 def test_trace_edge_ordering(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 2, 3)))
-  e2 = net.connect(a[1], a[0])
+  a = tn.Node(np.zeros((2, 2, 3)), backend=backend)
+  e2 = tn.connect(a[1], a[0])
   e3 = a[2]
   with pytest.raises(ValueError):
     a.reorder_edges([e2, e3])
 
 
 def test_mismatch_edge_ordering(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 3)))
+  a = tn.Node(np.zeros((2, 3)), backend=backend)
   e2_a = a[0]
-  b = net.add_node(np.zeros((2,)))
+  b = tn.Node(np.zeros((2,)), backend=backend)
   e_b = b[0]
   with pytest.raises(ValueError):
     a.reorder_edges([e2_a, e_b])
 
 
 def test_complicated_edge_reordering(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 3, 4)))
-  b = net.add_node(np.zeros((2, 5)))
-  c = net.add_node(np.zeros((3,)))
-  d = net.add_node(np.zeros((4, 5)))
-  e_ab = net.connect(a[0], b[0])
-  e_bd = net.connect(b[1], d[1])
-  e_ac = net.connect(a[1], c[0])
-  e_ad = net.connect(a[2], d[0])
-  net.contract(e_bd)
+  a = tn.Node(np.zeros((2, 3, 4)), backend=backend)
+  b = tn.Node(np.zeros((2, 5)), backend=backend)
+  c = tn.Node(np.zeros((3,)), backend=backend)
+  d = tn.Node(np.zeros((4, 5)), backend=backend)
+  e_ab = tn.connect(a[0], b[0])
+  e_bd = tn.connect(b[1], d[1])
+  e_ac = tn.connect(a[1], c[0])
+  e_ad = tn.connect(a[2], d[0])
+  result = tn.contract(e_bd)
   a.reorder_edges([e_ac, e_ab, e_ad])
-  net.check_correct()
+  tn.check_correct(tn.reachable(result))
   assert a.shape == (3, 2, 4)
 
 
 def test_edge_reorder_axis_names(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 3, 4, 5)), axis_names=["a", "b", "c", "d"])
+  a = tn.Node(np.zeros((2, 3, 4, 5)), axis_names=["a", "b", "c", "d"], backend=backend)
   edge_a = a["a"]
   edge_b = a["b"]
   edge_c = a["c"]
@@ -355,70 +326,64 @@ def test_edge_reorder_axis_names(backend):
 
 
 def test_add_axis_names(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2), name="A", axis_names=["ignore1", "ignore2"])
+  a = tn.Node(np.eye(2), name="A", axis_names=["ignore1", "ignore2"], backend=backend)
   a.add_axis_names(["a", "b"])
   assert a.axis_names == ["a", "b"]
 
 
 def test_reorder_axes(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.zeros((2, 3, 4)))
-  b = net.add_node(np.zeros((3, 4, 5)))
-  c = net.add_node(np.zeros((2, 4, 5)))
-  net.connect(a[0], c[0])
-  net.connect(b[0], a[1])
-  net.connect(a[2], c[1])
-  net.connect(b[2], c[2])
+  a = tn.Node(np.zeros((2, 3, 4)), backend=backend)
+  b = tn.Node(np.zeros((3, 4, 5)), backend=backend)
+  c = tn.Node(np.zeros((2, 4, 5)), backend=backend)
+  tn.connect(a[0], c[0])
+  tn.connect(b[0], a[1])
+  tn.connect(a[2], c[1])
+  tn.connect(b[2], c[2])
   a.reorder_axes([2, 0, 1])
-  net.check_correct()
+  tn.check_correct({a, b, c})
   assert a.shape == (4, 2, 3)
 
 
 def test_flatten_consistent_result(backend):
-  net_noflat = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((3, 5, 5, 6))
   b_val = np.ones((5, 6, 4, 5))
   # Create non flattened example to compare against.
-  a_noflat = net_noflat.add_node(a_val)
-  b_noflat = net_noflat.add_node(b_val)
-  e1 = net_noflat.connect(a_noflat[1], b_noflat[3])
-  e2 = net_noflat.connect(a_noflat[3], b_noflat[1])
-  e3 = net_noflat.connect(a_noflat[2], b_noflat[0])
+  a_noflat = tn.Node(a_val, backend=backend)
+  b_noflat = tn.Node(b_val, backend=backend)
+  e1 = tn.connect(a_noflat[1], b_noflat[3])
+  e2 = tn.connect(a_noflat[3], b_noflat[1])
+  e3 = tn.connect(a_noflat[2], b_noflat[0])
   a_dangling_noflat = a_noflat[0]
   b_dangling_noflat = b_noflat[2]
   for edge in [e1, e2, e3]:
-    net_noflat.contract(edge)
-  noflat_result_node = net_noflat.get_final_node()
+    noflat_result_node = tn.contract(edge)
   noflat_result_node.reorder_edges([a_dangling_noflat, b_dangling_noflat])
   noflat_result = noflat_result_node.tensor
   # Create network with flattening
-  net_flat = tensornetwork.TensorNetwork(backend=backend)
-  a_flat = net_flat.add_node(a_val)
-  b_flat = net_flat.add_node(b_val)
-  e1 = net_flat.connect(a_flat[1], b_flat[3])
-  e2 = net_flat.connect(a_flat[3], b_flat[1])
-  e3 = net_flat.connect(a_flat[2], b_flat[0])
+  a_flat = tn.Node(a_val, backend=backend)
+  b_flat = tn.Node(b_val, backend=backend)
+  e1 = tn.connect(a_flat[1], b_flat[3])
+  e2 = tn.connect(a_flat[3], b_flat[1])
+  e3 = tn.connect(a_flat[2], b_flat[0])
   a_dangling_flat = a_flat[0]
   b_dangling_flat = b_flat[2]
-  final_edge = net_flat.flatten_edges([e1, e2, e3])
-  flat_result_node = net_flat.contract(final_edge)
+  final_edge = tn.flatten_edges([e1, e2, e3])
+  flat_result_node = tn.contract(final_edge)
   flat_result_node.reorder_edges([a_dangling_flat, b_dangling_flat])
   flat_result = flat_result_node.tensor
   np.testing.assert_allclose(flat_result, noflat_result)
 
 
 def test_flatten_consistent_tensor(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((2, 3, 4, 5))
   b_val = np.ones((3, 5, 4, 2))
-  a = net.add_node(a_val)
-  b = net.add_node(b_val)
-  e1 = net.connect(a[0], b[3])
-  e2 = net.connect(b[1], a[3])
-  e3 = net.connect(a[1], b[0])
-  net.flatten_edges([e3, e1, e2])
-  net.check_correct()
+  a = tn.Node(a_val, backend=backend)
+  b = tn.Node(b_val, backend=backend)
+  e1 = tn.connect(a[0], b[3])
+  e2 = tn.connect(b[1], a[3])
+  e3 = tn.connect(a[1], b[0])
+  tn.flatten_edges([e3, e1, e2])
+  tn.check_correct({a, b})
 
   # Check expected values.
   a_final = np.reshape(np.transpose(a_val, (2, 1, 0, 3)), (4, 30))
@@ -428,61 +393,56 @@ def test_flatten_consistent_tensor(backend):
 
 
 def test_flatten_trace_consistent_result(backend):
-  net_noflat = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((5, 6, 6, 7, 5, 7))
-  a_noflat = net_noflat.add_node(a_val)
-  e1 = net_noflat.connect(a_noflat[0], a_noflat[4])
-  e2 = net_noflat.connect(a_noflat[1], a_noflat[2])
-  e3 = net_noflat.connect(a_noflat[3], a_noflat[5])
+  a_noflat = tn.Node(a_val, backend=backend)
+  e1 = tn.connect(a_noflat[0], a_noflat[4])
+  e2 = tn.connect(a_noflat[1], a_noflat[2])
+  e3 = tn.connect(a_noflat[3], a_noflat[5])
   for edge in [e1, e2, e3]:
-    net_noflat.contract(edge)
-  noflat_result = net_noflat.get_final_node().tensor
+    noflat_result = tn.contract(edge).tensor
   # Create network with flattening
-  net_flat = tensornetwork.TensorNetwork(backend=backend)
-  a_flat = net_flat.add_node(a_val)
-  e1 = net_flat.connect(a_flat[0], a_flat[4])
-  e2 = net_flat.connect(a_flat[1], a_flat[2])
-  e3 = net_flat.connect(a_flat[3], a_flat[5])
-  final_edge = net_flat.flatten_edges([e1, e2, e3])
-  flat_result = net_flat.contract(final_edge).tensor
+  a_flat = tn.Node(a_val)
+  e1 = tn.connect(a_flat[0], a_flat[4])
+  e2 = tn.connect(a_flat[1], a_flat[2])
+  e3 = tn.connect(a_flat[3], a_flat[5])
+  final_edge = tn.flatten_edges([e1, e2, e3])
+  flat_result = tn.contract(final_edge).tensor
   np.testing.assert_allclose(flat_result, noflat_result)
 
 
 def test_flatten_trace_consistent_tensor(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((5, 3, 4, 4, 5))
-  a = net.add_node(a_val)
-  e1 = net.connect(a[0], a[4])
-  e2 = net.connect(a[3], a[2])
-  net.flatten_edges([e2, e1])
-  net.check_correct()
+  a = tn.Node(a_val, backend=backend)
+  e1 = tn.connect(a[0], a[4])
+  e2 = tn.connect(a[3], a[2])
+  tn.flatten_edges([e2, e1])
+  tn.check_correct({a})
   # Check expected values.
   a_final = np.reshape(np.transpose(a_val, (1, 2, 0, 3, 4)), (3, 20, 20))
   np.testing.assert_allclose(a.tensor, a_final)
 
 
 def test_contract_between_output_order(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((2, 3, 4, 5))
   b_val = np.ones((3, 5, 4, 2))
   c_val = np.ones((2, 2))
-  a = net.add_node(a_val)
-  b = net.add_node(b_val)
-  c = net.add_node(c_val)
-  net.connect(a[0], b[3])
-  net.connect(b[1], a[3])
-  net.connect(a[1], b[0])
+  a = tn.Node(a_val, backend=backend)
+  b = tn.Node(b_val, backend=backend)
+  c = tn.Node(c_val, backend=backend)
+  tn.connect(a[0], b[3])
+  tn.connect(b[1], a[3])
+  tn.connect(a[1], b[0])
   with pytest.raises(ValueError):
-    d = net.contract_between(
+    d = tn.contract_between(
         a, b, name="New Node", output_edge_order=[a[2], b[2], a[0]])
-  net.check_correct(check_connections=False)
+  tn.check_correct({a, b, c}, check_connections=False)
   with pytest.raises(ValueError):
-    d = net.contract_between(
+    d = tn.contract_between(
         a, b, name="New Node", output_edge_order=[a[2], b[2], c[0]])
-  net.check_correct(check_connections=False)
-  d = net.contract_between(
+  tn.check_correct({a, b, c}, check_connections=False)
+  d = tn.contract_between(
       a, b, name="New Node", output_edge_order=[b[2], a[2]])
-  net.check_correct(check_connections=False)
+  tn.check_correct({c, d}, check_connections=False)
   a_flat = np.reshape(np.transpose(a_val, (2, 1, 0, 3)), (4, 30))
   b_flat = np.reshape(np.transpose(b_val, (2, 0, 3, 1)), (4, 30))
   final_val = np.matmul(b_flat, a_flat.T)
@@ -491,247 +451,82 @@ def test_contract_between_output_order(backend):
 
 
 def test_contract_between_trace_edges(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
   a_val = np.ones((3, 3))
   final_val = np.trace(a_val)
-  a = net.add_node(a_val)
-  net.connect(a[0], a[1])
-  b = net.contract_between(a, a)
-  net.check_correct()
+  a = tn.Node(a_val, backend=backend)
+  tn.connect(a[0], a[1])
+  b = tn.contract_between(a, a)
+  tn.check_correct({b})
   np.testing.assert_allclose(b.tensor, final_val)
 
 
-def test_contract_disable(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.random.rand(2, 2))
-  b = net.add_node(np.random.rand(2, 2))
-  e = net.connect(a[0], b[0])
-  net.contract(e)
-  with pytest.raises(ValueError):
-    a.edges[0]
-  with pytest.raises(ValueError):
-    a.edges
-  with pytest.raises(ValueError):
-    a.signature
-  with pytest.raises(ValueError):
-    a.shape
-  with pytest.raises(ValueError):
-    b.edges[0]
-  with pytest.raises(ValueError):
-    b.edges
-  with pytest.raises(ValueError):
-    b.signature
-  with pytest.raises(ValueError):
-    b.shape
-
-
-def test_contract_between_disable(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.random.rand(2, 2))
-  b = net.add_node(np.random.rand(2, 2))
-  net.connect(a[1], b[0])
-  net.contract_between(a, b)
-  with pytest.raises(ValueError):
-    a.edges[0]
-  with pytest.raises(ValueError):
-    a.edges
-  with pytest.raises(ValueError):
-    a.signature
-  with pytest.raises(ValueError):
-    a.shape
-  with pytest.raises(ValueError):
-    b.edges[0]
-  with pytest.raises(ValueError):
-    b.edges
-  with pytest.raises(ValueError):
-    b.signature
-  with pytest.raises(ValueError):
-    b.shape
-
-
-def test_double_trace_disable(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  node = net.add_node(np.random.rand(2, 2, 2, 2), name='node1')
-
-  e1 = net.connect(node[0], node[2], name='e1')
-  net.connect(node[1], node[3], name='e2')
-
-  # contract disables contracted edges;
-  # if we have to access them, we need
-  # to do it beforehand.
-  node1 = e1.node1
-  node2 = e1.node2
-
-  net.contract(e1, name='b')
-
-  with pytest.raises(ValueError):
-    node.edges[0]
-  with pytest.raises(ValueError):
-    node.edges
-  with pytest.raises(ValueError):
-    node.signature
-  with pytest.raises(ValueError):
-    node.shape
-
-  with pytest.raises(ValueError):
-    node1.edges[0]
-  with pytest.raises(ValueError):
-    node1.edges
-  with pytest.raises(ValueError):
-    node1.signature
-  with pytest.raises(ValueError):
-    node1.shape
-
-  with pytest.raises(ValueError):
-    node2.edges[0]
-  with pytest.raises(ValueError):
-    node2.edges
-  with pytest.raises(ValueError):
-    node2.signature
-  with pytest.raises(ValueError):
-    node2.shape
-
-
-def test_trace_disable(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  node = net.add_node(np.random.rand(2, 2, 2, 2), name='node1')
-  e = net.connect(node[0], node[2], name='e1')
-  # _contract_trace disables contracted edges;
-  # if we have to access them, we need
-  # to do it beforehand.
-  node1 = e.node1
-  node2 = e.node2
-
-  net._contract_trace(e, name='b')
-
-  with pytest.raises(ValueError):
-    node.edges[0]
-  with pytest.raises(ValueError):
-    node.edges
-  with pytest.raises(ValueError):
-    node.signature
-  with pytest.raises(ValueError):
-    node.shape
-
-  with pytest.raises(ValueError):
-    node1.edges[0]
-  with pytest.raises(ValueError):
-    node1.edges
-  with pytest.raises(ValueError):
-    node1.signature
-  with pytest.raises(ValueError):
-    node1.shape
-  with pytest.raises(ValueError):
-    node2.edges[0]
-  with pytest.raises(ValueError):
-    node2.edges
-  with pytest.raises(ValueError):
-    node2.signature
-  with pytest.raises(ValueError):
-    node2.shape
-
-
-def test_weakref(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  e = net.connect(a[0], b[0])
-  del a
-  del b
-  net.contract(e)
-  with pytest.raises(ValueError):
-    e.node1
-  with pytest.raises(ValueError):
-    e.node2
-
-
-# This test no longer tests weakref behaviour
-# since contraction methods now automatically
-# disable contracted edges by setting Edge.node1 and
-# Edge.node2 to None.
-def test_weakref_complex(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  c = net.add_node(np.eye(2))
-  e1 = net.connect(a[0], b[0])
-  e2 = net.connect(b[1], c[0])
-  net.contract(e1)
-  net.contract(e2)
+def test_disable_edges_complex(backend):
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  c = tn.Node(np.eye(2), backend=backend)
+  e1 = tn.connect(a[0], b[0])
+  e2 = tn.connect(b[1], c[0])
+  tn.contract(e1)
+  tn.contract(e2)
   # This now raises an exception because we contract disables contracted edges
   # and raises a ValueError if we try to access the nodes
   with pytest.raises(ValueError):
     e1.node1
-  # This raises an exception since the intermediate node created when doing
-  # `net.contract(e2)` was garbage collected.
   with pytest.raises(ValueError):
     e2.node1
 
 
 def test_edge_disable_complex(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  c = net.add_node(np.eye(2))
-  e1 = net.connect(a[0], b[0])
-  e2 = net.connect(b[1], c[0])
-  net.contract(e1)
-  net.contract(e2)
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  c = tn.Node(np.eye(2), backend=backend)
+  e1 = tn.connect(a[0], b[0])
+  e2 = tn.connect(b[1], c[0])
+  tn.contract(e1)
+  tn.contract(e2)
   # This now raises an exception because we contract disables contracted edges
   # and raises a ValueError if we try to access the nodes
   with pytest.raises(ValueError):
     e1.node1
   # This raises an exception since the intermediate node created when doing
-  # `net.contract(e2)` was garbage collected.
+  # `tn.contract(e2)` was garbage collected.
   with pytest.raises(ValueError):
     e2.node1
 
 
 def test_set_node2(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  e = net.connect(a[0], b[0])
+  a = tn.Node(np.eye(2), backend=backend)
+  b = tn.Node(np.eye(2), backend=backend)
+  e = tn.connect(a[0], b[0])
   # You should never do this, but if you do, we should handle
   # it gracefully.
   e.node2 = None
   assert e.is_dangling()
 
 
-def test_contracted_node_not_in_network(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2)))
-  e = net.connect(a[0], a[1])
-  net.contract(e)
-  assert a not in net
-
-
 def test_set_default(backend):
-  tensornetwork.set_default_backend(backend)
-  assert tensornetwork.config.default_backend == backend
-  net = tensornetwork.TensorNetwork()
-  assert net.backend.name == backend
-
+  tn.set_default_backend(backend)
+  assert tn.config.default_backend == backend
+  a = tn.Node(np.eye(2))
+  assert a.backend.name == backend
 
 def test_copy_tensor(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([1, 2, 3], dtype=np.float64))
-  b = net.add_node(np.array([10, 20, 30], dtype=np.float64))
-  c = net.add_node(np.array([5, 6, 7], dtype=np.float64))
-  d = net.add_node(np.array([1, -1, 1], dtype=np.float64))
-  cn = net.add_copy_node(rank=4, dimension=3)
-  edge1 = net.connect(a[0], cn[0])
-  edge2 = net.connect(b[0], cn[1])
-  edge3 = net.connect(c[0], cn[2])
-  edge4 = net.connect(d[0], cn[3])
+  a = tn.Node(np.array([1, 2, 3], dtype=np.float64), backend=backend)
+  b = tn.Node(np.array([10, 20, 30], dtype=np.float64), backend=backend)
+  c = tn.Node(np.array([5, 6, 7], dtype=np.float64), backend=backend)
+  d = tn.Node(np.array([1, -1, 1], dtype=np.float64), backend=backend)
+  cn = tn.CopyNode(rank=4, dimension=3, backend=backend)
+  edge1 = tn.connect(a[0], cn[0])
+  edge2 = tn.connect(b[0], cn[1])
+  edge3 = tn.connect(c[0], cn[2])
+  edge4 = tn.connect(d[0], cn[3])
 
   result = cn.compute_contracted_tensor()
   assert list(result.shape) == []
   np.testing.assert_allclose(result, 50 - 240 + 630)
 
   for edge in [edge1, edge2, edge3, edge4]:
-    net.contract(edge)
-  val = net.get_final_node()
+    val = tn.contract(edge)
   result = val.tensor
   assert list(result.shape) == []
   np.testing.assert_allclose(result, 50 - 240 + 630)
@@ -740,47 +535,40 @@ def test_copy_tensor(backend):
 # Include 'tensorflow' (by removing the decorator) once #87 is fixed.
 @pytest.mark.parametrize('backend', ('numpy', 'jax'))
 def test_copy_tensor_parallel_edges(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.diag([1., 2, 3]))
-  b = net.add_node(np.array([10, 20, 30], dtype=np.float64))
-  cn = net.add_copy_node(rank=3, dimension=3)
-  edge1 = net.connect(a[0], cn[0])
-  edge2 = net.connect(a[1], cn[1])
-  edge3 = net.connect(b[0], cn[2])
+  a = tn.Node(np.diag([1., 2, 3]), backend=backend)
+  b = tn.Node(np.array([10, 20, 30], dtype=np.float64), backend=backend)
+  cn = tn.CopyNode(rank=3, dimension=3, backend=backend)
+  edge1 = tn.connect(a[0], cn[0])
+  edge2 = tn.connect(a[1], cn[1])
+  edge3 = tn.connect(b[0], cn[2])
 
   result = cn.compute_contracted_tensor()
   assert list(result.shape) == []
   np.testing.assert_allclose(result, 10 + 40 + 90)
 
   for edge in [edge1, edge2, edge3]:
-    net.contract(edge)
-  val = net.get_final_node()
+    val = tn.contract(edge)
   result = val.tensor
   assert list(result.shape) == []
   np.testing.assert_allclose(result, 10 + 40 + 90)
 
 
 def test_contract_copy_node_connected_neighbors(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.array([[1, 2, 3], [10, 20, 30]], dtype=np.float64))
-  b = net.add_node(np.array([[2, 1, 1], [2, 2, 2]], dtype=np.float64))
-  c = net.add_node(np.array([3, 4, 4], dtype=np.float64))
-  cn = net.add_copy_node(rank=3, dimension=3)
-  net.connect(a[0], b[0])
-  net.connect(a[1], cn[0])
-  net.connect(b[1], cn[1])
-  net.connect(c[0], cn[2])
+  a = tn.Node(np.array([[1, 2, 3], [10, 20, 30]]), backend=backend)
+  b = tn.Node(np.array([[2, 1, 1], [2, 2, 2]]), backend=backend)
+  c = tn.Node(np.array([3, 4, 4]), backend=backend)
+  cn = tn.CopyNode(rank=3, dimension=3, backend=backend)
+  tn.connect(a[0], b[0])
+  tn.connect(a[1], cn[0])
+  tn.connect(b[1], cn[1])
+  tn.connect(c[0], cn[2])
 
-  n = net.contract_copy_node(cn)
+  n = tn.contract_copy_node(cn)
 
-  with pytest.raises(ValueError):
-    val = net.get_final_node()
-  assert len(net.nodes_set) == 1
   assert len(n.edges) == 2
   assert n.edges[0] == n.edges[1]
 
-  net.contract_parallel(n.edges[0])
-  val = net.get_final_node()
+  val = tn.contract_parallel(n.edges[0])
   result = val.tensor
   assert list(result.shape) == []
   np.testing.assert_allclose(result, 26 + 460)
@@ -788,18 +576,16 @@ def test_contract_copy_node_connected_neighbors(backend):
 
 def test_bad_backend():
   with pytest.raises(ValueError):
-    tensornetwork.TensorNetwork("NOT_A_BACKEND")
+    tn.Node(np.eye(2), backend="BAD_BACKEND_NAME")
 
 
 def test_remove_node(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2, 2)), axis_names=["test", "names", "ignore"])
-  b = net.add_node(np.ones((2, 2)))
-  c = net.add_node(np.ones((2, 2)))
-  net.connect(a["test"], b[0])
-  net.connect(a[1], c[0])
-  broken_edges_name, broken_edges_axis = net.remove_node(a)
-  assert a not in net
+  a = tn.Node(np.ones((2, 2, 2)), axis_names=["test", "names", "ignore"], backend=backend)
+  b = tn.Node(np.ones((2, 2)), backend=backend)
+  c = tn.Node(np.ones((2, 2)), backend=backend)
+  tn.connect(a["test"], b[0])
+  tn.connect(a[1], c[0])
+  broken_edges_name, broken_edges_axis = tn.remove_node(a)
   assert "test" in broken_edges_name
   assert broken_edges_name["test"] is b[0]
   assert "names" in broken_edges_name
@@ -813,119 +599,39 @@ def test_remove_node(backend):
 
 
 def test_remove_node_trace_edge(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2, 2)))
-  b = net.add_node(np.ones(2))
-  net.connect(a[0], b[0])
-  net.connect(a[1], a[2])
-  _, broken_edges = net.remove_node(a)
+  a = tn.Node(np.ones((2, 2, 2)), backend=backend)
+  b = tn.Node(np.ones(2), backend=backend)
+  tn.connect(a[0], b[0])
+  tn.connect(a[1], a[2])
+  _, broken_edges = tn.remove_node(a)
   assert 0 in broken_edges
   assert 1 not in broken_edges
   assert 2 not in broken_edges
   assert broken_edges[0] is b[0]
 
 
-def test_subnetwork_signatures(backend):
-  net1 = tensornetwork.TensorNetwork(backend=backend)
-  net2 = tensornetwork.TensorNetwork(backend=backend)
-  a = net1.add_node(np.eye(2))
-  assert a.signature == 1
-  b = net2.add_node(np.eye(2))
-  assert b.signature == 1
-  net1.add_subnetwork(net2)
-  assert b.signature == 2
-
-
-def test_edges_signatures(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2,) * 5))
-  b = net.add_node(np.ones((2,) * 5))
-  for i in range(5):
-    assert a[i].signature == -1
-    assert b[i].signature == -1
-  for i, index in enumerate({1, 3, 4}):
-    edge = net.connect(a[index], b[index])
-    # Add 11 to account for the the original 10
-    # edges and the 1 indexing.
-    assert edge.signature == i + 11
-
-
 def test_at_operator(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2,)))
-  b = net.add_node(np.ones((2,)))
-  net.connect(a[0], b[0])
+  a = tn.Node(np.ones((2,)), backend=backend)
+  b = tn.Node(np.ones((2,)), backend=backend)
+  tn.connect(a[0], b[0])
   c = a @ b
-  assert isinstance(c, tensornetwork.Node)
+  assert isinstance(c, tn.Node)
   np.testing.assert_allclose(c.tensor, 2.0)
 
 
-def test_at_operator_out_of_network(backend):
-  net1 = tensornetwork.TensorNetwork(backend=backend)
-  net2 = tensornetwork.TensorNetwork(backend=backend)
-  a = net1.add_node(np.ones((2,)))
-  b = net2.add_node(np.ones((2,)))
-  with pytest.raises(ValueError):
-    a = a @ b
-
-
-def test_edge_sorting(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.eye(2))
-  b = net.add_node(np.eye(2))
-  c = net.add_node(np.eye(2))
-  e1 = net.connect(a[0], b[1])
-  e2 = net.connect(b[0], c[1])
-  e3 = net.connect(c[0], a[1])
-  sorted_edges = sorted([e2, e3, e1])
-  assert sorted_edges == [e1, e2, e3]
-
-
 def test_connect_alias(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2)))
-  b = net.add_node(np.ones((2, 2)))
+  a = tn.Node(np.ones((2, 2)), backend=backend)
+  b = tn.Node(np.ones((2, 2)), backend=backend)
   e = a[0] ^ b[0]
   assert set(e.get_nodes()) == {a, b}
   assert e is a[0]
   assert e is b[0]
-  assert e in net
 
 
 def test_remove_after_flatten(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.ones((2, 2)))
-  b = net.add_node(np.ones((2, 2)))
-  net.connect(a[0], b[0])
-  net.connect(a[1], b[1])
-  net.flatten_all_edges()
-  net.remove_node(a)
-
-
-def test_disable_node(backend):
-  net = tensornetwork.TensorNetwork(backend=backend)
-  a = net.add_node(np.random.rand(2, 3, 4, 5, 6))
-  with pytest.raises(ValueError):
-    a.disable()
-
-
-@pytest.mark.parametrize("backend,dtype", [
-    *list(zip(['numpy'] * len(np_dtypes), np_dtypes)),
-    *list(zip(['tensorflow'] * len(tf_dtypes), tf_dtypes)),
-    *list(zip(['pytorch'] * len(torch_dtypes), torch_dtypes)),
-    *list(zip(['jax'] * len(jax_dtypes), jax_dtypes)),
-])
-def test_network_backend_dtype_1(backend, dtype):
-  net = tensornetwork.TensorNetwork(backend=backend, dtype=dtype)
-  n1 = net.add_node(net.backend.zeros((2, 2)))
-  assert n1.tensor.dtype == dtype
-
-
-@pytest.mark.parametrize("backend,dtype", [('numpy', np.float32),
-                                           ('tensorflow', tf.float32),
-                                           ('pytorch', torch.float32),
-                                           ('jax', np.float32)])
-def test_network_backend_dtype_3(backend, dtype):
-  net = tensornetwork.TensorNetwork(backend=backend, dtype=dtype)
-  with pytest.raises(TypeError):
-    net.add_node(np.random.rand(3, 3))
+  a = tn.Node(np.ones((2, 2)), backend=backend)
+  b = tn.Node(np.ones((2, 2)), backend=backend)
+  tn.connect(a[0], b[0])
+  tn.connect(a[1], b[1])
+  tn.flatten_all_edges({a, b})
+  tn.remove_node(a)

--- a/tensornetwork/tests/tensornetwork_test.py
+++ b/tensornetwork/tests/tensornetwork_test.py
@@ -59,7 +59,7 @@ def test_add_node_names(backend):
 
 def test_add_copy_node_from_node_object(backend):
   a = tn.CopyNode(
-          3, 3, name="TestName", axis_names=['a', 'b', 'c'], backend=backend)
+      3, 3, name="TestName", axis_names=['a', 'b', 'c'], backend=backend)
   assert a.shape == (3, 3, 3)
   assert isinstance(a, tn.CopyNode)
   assert a.name == "TestName"
@@ -315,7 +315,9 @@ def test_complicated_edge_reordering(backend):
 
 
 def test_edge_reorder_axis_names(backend):
-  a = tn.Node(np.zeros((2, 3, 4, 5)), axis_names=["a", "b", "c", "d"], backend=backend)
+  a = tn.Node(
+      np.zeros((2, 3, 4, 5)), axis_names=["a", "b", "c", "d"], 
+      backend=backend)
   edge_a = a["a"]
   edge_b = a["b"]
   edge_c = a["c"]
@@ -326,7 +328,9 @@ def test_edge_reorder_axis_names(backend):
 
 
 def test_add_axis_names(backend):
-  a = tn.Node(np.eye(2), name="A", axis_names=["ignore1", "ignore2"], backend=backend)
+  a = tn.Node(
+      np.eye(2), name="A", axis_names=["ignore1", "ignore2"], 
+      backend=backend)
   a.add_axis_names(["a", "b"])
   assert a.axis_names == ["a", "b"]
 
@@ -580,7 +584,9 @@ def test_bad_backend():
 
 
 def test_remove_node(backend):
-  a = tn.Node(np.ones((2, 2, 2)), axis_names=["test", "names", "ignore"], backend=backend)
+  a = tn.Node(
+      np.ones((2, 2, 2)), axis_names=["test", "names", "ignore"], 
+      backend=backend)
   b = tn.Node(np.ones((2, 2)), backend=backend)
   c = tn.Node(np.ones((2, 2)), backend=backend)
   tn.connect(a["test"], b[0])


### PR DESCRIPTION
Removed the use of TensorNetwork in several of the files of `tests/`

Added `copy` and `remove_node` operations to work outside of a TensorNetwork.

Finally, I removed the weakrefs from the code. We may consider adding a `node.deallocate()` method in the future to free up memory manually.

The serialization tests still need to be fixed.