### PR TITLE
bump version

### DIFF
--- a/tensornetwork/version.py
+++ b/tensornetwork/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'


### PR DESCRIPTION
Version 0.2.0 will be when `TensorNetwork` is fully nuked. This is the "inbetween" release where we support both free nodes and `TensorNetwork`s