### PR TITLE
Added split_edge method

### DIFF
--- a/tensornetwork/__init__.py
+++ b/tensornetwork/__init__.py
@@ -5,7 +5,7 @@ from tensornetwork.network_components import Node, Edge, CopyNode, BaseNode, Nod
 
 from tensornetwork.network_operations import conj, copy, transpose, split_node, split_node_qr, split_node_rq, split_node_full_svd, reachable, check_connected, check_correct, get_all_nodes, get_all_edges, remove_node, contract_trace_edges
 
-from tensornetwork.network_components import contract, contract_copy_node, contract_between, outer_product, outer_product_final_nodes, contract_parallel, flatten_edges, get_all_nondangling, get_all_dangling, flatten_all_edges, flatten_edges_between, get_parallel_edges, get_shared_edges
+from tensornetwork.network_components import contract, contract_copy_node, contract_between, outer_product, outer_product_final_nodes, contract_parallel, flatten_edges, split_edge, get_all_nondangling, get_all_dangling, flatten_all_edges, flatten_edges_between, get_parallel_edges, get_shared_edges
 
 from tensornetwork.network_components import connect, disconnect
 from tensornetwork.ncon_interface import ncon, ncon_network

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -32,7 +32,7 @@ class NumPyBackend(base_backend.BaseBackend):
     return self.np.tensordot(a, b, axes)
 
   def reshape(self, tensor: Tensor, shape: Tensor):
-    return self.np.reshape(tensor, shape.astype(self.np.int32))
+    return self.np.reshape(tensor, self.np.asarray(shape).astype(self.np.int32))
 
   def transpose(self, tensor, perm):
     return self.np.transpose(tensor, perm)

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -1367,7 +1367,7 @@ def _split_trace_edge(edge: Edge,
 
 
 def split_edge(edge: Edge,
-               shape: Tuple[int],
+               shape: Tuple[int, ...],
                new_edge_names: Optional[List[Text]] = None) ->  List[Edge]:
   """Split an `Edge` into multiple edges according to `shape`. Reshapes
   the underlying tensors connected to the edge accordingly. 

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -798,13 +798,13 @@ class Edge:
   Dangling Edge:
     A dangling edge is an edge that only connects to a single node and only one
     part of the edge connects to the node. The other end is left "dangling".
-    These types of edges can not be contrated and represent additional
+    These types of edges can not be contracted and represent additional
     dimensions on the underlying tensor. After all other edges are contracted,
     the final result will have the same rank as the number of dangling edges. If
     there are no dangling edges, then the final value will be a scalar.
 
   Trace Edges:
-    Trace edges are edges that connects a node to itself. These edges represent
+    Trace edges are edges that connect a node to itself. These edges represent
     a trace along the given axis. Once again, the axes must be the same
     dimension.
   """
@@ -1208,7 +1208,6 @@ def flatten_edges(edges: List[Edge],
 
   Args:
     edges: A list of edges to flatten.
-    backend: A backend object
     new_edge_name: Optional name to give to the newly created edge.
 
   Returns:
@@ -1301,7 +1300,7 @@ def flatten_edges_between(
 
   Returns:
     The flattened `Edge` object. If there was only one edge between the two
-      nodes, then the original edge is returned. If there where no edges
+      nodes, then the original edge is returned. If there were no edges
       between the nodes, a None is returned.
   """
   shared_edges = get_shared_edges(node1, node2)
@@ -1324,6 +1323,131 @@ def flatten_all_edges(nodes: Iterable[BaseNode]) -> List[Edge]:
       flattened_edges.append(flat_edge)
   return flattened_edges
 
+
+def _split_trace_edge(edge: Edge,
+                      shape: Tuple[int],
+                      new_edge_names: Optional[List[Text]] = None,
+                      ) -> List[Edge]:
+  """Split trace edges into single edge.
+
+  Args:
+    edge: Trace edge to split.
+    shape: Tuple of integers used to split trace edge into multiple edges.
+    new_edge_names: Optional names of the new edges created.
+
+  Returns:
+    A list of new edges where the product of the dimensions of the new
+    edges corresponds to the dimension of the edge before splitting.
+  """
+  node = edge.node1  # We are in the trace case, so this is the only node.
+  backend = node.backend
+  # Permute until edge axes to be split are at the back and reshape.
+  perm_back = [min(edge.axis1, edge.axis2)]
+  perm_back += [max(edge.axis1, edge.axis2)]
+  perm_front = set(range(len(node.edges))) - set(perm_back)
+  perm_front = sorted(perm_front)
+  node.reorder_axes(perm_front + perm_back)
+  unaffected_shape = backend.shape_tuple(node.tensor)[:len(perm_front)]
+  new_shape = unaffected_shape + shape + shape
+  node.tensor = backend.reshape(node.tensor, new_shape)
+  # Trim edges and add placeholder edges for new axes.
+  node.edges = node.edges[:len(perm_front)] + 2 * len(shape) * [None] 
+  # Create new dangling edges and connect them to each other.
+  new_edges = []
+  for idx in range(len(shape)):
+    edge1 = Edge(node1=node, axis1=len(perm_front) + idx)
+    edge2 = Edge(node1=node, axis1=len(perm_front) + len(shape) + idx)
+    node.edges[len(perm_front) + idx] = edge1
+    node.edges[len(perm_front) + len(shape) + idx] = edge2
+    new_edges.append(connect(edge1, edge2,
+        new_edge_names[idx] if new_edge_names is not None else None))
+  # pylint: disable=expression-not-assigned
+  edge.disable() # disable old edge!
+  return new_edges
+
+
+def split_edge(edge: Edge,
+               shape: Tuple[int],
+               new_edge_names: Optional[List[Text]] = None) ->  List[Edge]:
+  """Split an `Edge` into multiple edges according to `shape`. Reshapes
+  the underlying tensors connected to the edge accordingly. 
+  
+  This method acts as the inverse operation of flattening edges and
+  distinguishes between the following edge cases when adding new edges:
+    1) standard edge connecting two different nodes: reshape node dimensions
+    2) dangling edge (node2 is None): reshape node1 dimension
+    3) trace edge (node1 is node2): reshape node1 dimension
+
+  Args:
+    edge: Edge to split.
+    shape: Tuple of integers used to split edge into multiple edges.
+
+  Returns:
+    A list of new edges where the product of the dimensions of the new
+    edges corresponds to the dimension of the edge before splitting.
+
+  Raises:
+    ValueError: If the edge dimension mismatches with the split shape.
+    ValueError: If the edge is connecting nodes with different backends.
+  """
+
+  # Check if reshape operation is possible.
+  if not np.prod(shape) == edge.dimension:
+    raise ValueError(
+          "Edge {} with dimension {} cannot be split according to "
+          "shape {}.".format(edge, edge.dimension, shape))
+
+  # Handle trace edge case separately.
+  if edge.is_trace():
+    return _split_trace_edge(edge, shape, new_edge_names)
+
+  backends = [node.backend for node in edge.get_nodes() if node is not None]
+  if not all([b.name == backends[0].name for b in backends]):
+    raise ValueError("Not all backends are the same.")
+  backend = backends[0]
+  expected_nodes = set(edge.get_nodes())
+
+  # Split standard or dangling edge.
+  new_dangling_edges = []
+  for node in expected_nodes:
+    # Required for dangling case.
+    if node is None:
+      continue
+    # Permute until edge axes to be split are at the back and reshape.
+    perm_back = [node.edges.index(edge)]
+    perm_front = set(range(len(node.edges))) - set(perm_back)
+    perm_front = sorted(perm_front)
+    node.reorder_axes(perm_front + perm_back)
+    unaffected_shape = backend.shape_tuple(node.tensor)[:len(perm_front)]
+    new_shape = unaffected_shape + shape
+    node.tensor = backend.reshape(node.tensor, new_shape) # in-place update    
+    # Trim edges.
+    node.edges = node.edges[:len(perm_front)]
+    # Create new dangling edges.    
+    for idx in range(len(shape)):
+      new_dangling_edge = Edge(node1=node, axis1=len(perm_front) + idx,
+                                name=new_edge_names[idx] if new_edge_names
+                                  is not None else None)
+      node.edges += [new_dangling_edge]      
+      new_dangling_edges.append(new_dangling_edge)
+
+  node1, node2 = tuple(expected_nodes)
+  # pylint: disable=expression-not-assigned
+  edge.disable() # disable old edge
+
+  # Return new dangling edges for dangling case.
+  if node1 is None or node2 is None:
+    return new_dangling_edges
+
+  # Create connected edges between nodes for standard case.
+  new_edges = []
+  for idx in range(len(shape)):    
+    new_edges.append(connect(new_dangling_edges[idx],
+                             new_dangling_edges[len(shape) + idx],
+                             new_edge_names[idx] if new_edge_names
+                              is not None else None))  
+  return new_edges
+  
 
 def _remove_trace_edge(edge: Edge, new_node: BaseNode) -> None:
   """Collapse a trace edge. `edge` is disabled before returning.
@@ -1596,7 +1720,7 @@ def connect(edge1: Edge, edge2: Edge, name: Optional[Text] = None) -> Edge:
                      "Dimension of edge '{}': {}.".format(
                          edge1, edge1.dimension, edge2, edge2.dimension))
 
-  #edge1 and edg2 are always dangling in this case
+  #edge1 and edge2 are always dangling in this case
   node1 = edge1.node1
   node2 = edge2.node1
   axis1_num = node1.get_axis_number(edge1.axis1)

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -1325,7 +1325,7 @@ def flatten_all_edges(nodes: Iterable[BaseNode]) -> List[Edge]:
 
 
 def _split_trace_edge(edge: Edge,
-                      shape: Tuple[int],
+                      shape: Tuple[int, ...],
                       new_edge_names: Optional[List[Text]] = None,
                       ) -> List[Edge]:
   """Split trace edges into single edge.

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -1405,7 +1405,7 @@ def split_edge(edge: Edge,
         "shape {}.".format(edge, edge.dimension, shape))
   # Check if possible reshape operation is trivial.
   if len(shape) == 1:
-    return edge
+    return [edge]
 
   # Handle trace edge case separately.
   if edge.is_trace():

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -1360,7 +1360,8 @@ def _split_trace_edge(edge: Edge,
     node.edges[len(perm_front) + idx] = edge1
     node.edges[len(perm_front) + len(shape) + idx] = edge2
     new_edges.append(connect(edge1, edge2,
-        new_edge_names[idx] if new_edge_names is not None else None))
+                             new_edge_names[idx] if new_edge_names is not None
+                             else None))
   # pylint: disable=expression-not-assigned
   edge.disable() # disable old edge!
   return new_edges
@@ -1394,8 +1395,8 @@ def split_edge(edge: Edge,
   # Check if reshape operation is possible.
   if not np.prod(shape) == edge.dimension:
     raise ValueError(
-          "Edge {} with dimension {} cannot be split according to "
-          "shape {}.".format(edge, edge.dimension, shape))
+        "Edge {} with dimension {} cannot be split according to "
+        "shape {}.".format(edge, edge.dimension, shape))
 
   # Handle trace edge case separately.
   if edge.is_trace():
@@ -1426,8 +1427,8 @@ def split_edge(edge: Edge,
     # Create new dangling edges.    
     for idx in range(len(shape)):
       new_dangling_edge = Edge(node1=node, axis1=len(perm_front) + idx,
-                                name=new_edge_names[idx] if new_edge_names
-                                  is not None else None)
+                               name=new_edge_names[idx] if new_edge_names
+                               is not None else None)
       node.edges += [new_dangling_edge]      
       new_dangling_edges.append(new_dangling_edge)
 
@@ -1445,7 +1446,7 @@ def split_edge(edge: Edge,
     new_edges.append(connect(new_dangling_edges[idx],
                              new_dangling_edges[len(shape) + idx],
                              new_edge_names[idx] if new_edge_names
-                              is not None else None))  
+                             is not None else None))  
   return new_edges
   
 


### PR DESCRIPTION
Attempt to resolve #150. First PR for this project so comments definitely welcome. Pull request also contains random typos I came across and a tiny change to the `reshape` wrapper for the numpy backend (to enable tuple support for the `shape` argument and align it with the other backends). Unit tests pass but I haven't tried the method in the context of a larger script.