### PR TITLE
remove dtype from backends

### DIFF
--- a/tensornetwork/backends/backend_factory.py
+++ b/tensornetwork/backends/backend_factory.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from tensornetwork.backends.tensorflow import tensorflow_backend
 from tensornetwork.backends.numpy import numpy_backend
 from tensornetwork.backends.jax import jax_backend
@@ -28,7 +27,7 @@ _BACKENDS = {
 }
 
 
-def get_backend(name, dtype):
+def get_backend(name):
   if name not in _BACKENDS:
     raise ValueError("Backend '{}' does not exist".format(name))
-  return _BACKENDS[name](dtype)
+  return _BACKENDS[name]()

--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -24,15 +24,6 @@ class BaseBackend:
   def __init__(self):
     self.name = 'base backend'
 
-  @property
-  def dtype(self):
-    return self._dtype
-
-  @dtype.setter
-  def dtype(self, dtype):
-    #pylint: disable=attribute-defined-outside-init
-    self._dtype = dtype
-
   def tensordot(self, a: Tensor, b: Tensor,
                 axes: Sequence[Sequence[int]]) -> Tensor:
     """Do a tensordot of tensors `a` and `b` over the given axes.
@@ -285,16 +276,16 @@ class BaseBackend:
     raise NotImplementedError("Backend '{}' has not implemented conj.".format(
         self.name))
 
-  def eigsh_lanczos(
-      self,
-      A: Callable,
-      initial_state: Optional[Tensor] = None,
-      ncv: Optional[int] = 200,
-      numeig: Optional[int] = 1,
-      tol: Optional[float] = 1E-8,
-      delta: Optional[float] = 1E-8,
-      ndiag: Optional[int] = 20,
-      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
+  def eigsh_lanczos(self,
+                    A: Callable,
+                    initial_state: Optional[Tensor] = None,
+                    ncv: Optional[int] = 200,
+                    numeig: Optional[int] = 1,
+                    tol: Optional[float] = 1E-8,
+                    delta: Optional[float] = 1E-8,
+                    ndiag: Optional[int] = 20,
+                    reorthogonalize: Optional[bool] = False
+                   ) -> Tuple[List, List]:
     """
     Lanczos method for finding the lowest eigenvector-eigenvalue pairs
     of `A`. 

--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -37,10 +37,6 @@ class JaxBackend(numpy_backend.NumPyBackend):
 
   def convert_to_tensor(self, tensor: Tensor) -> Tensor:
     result = self.jax.jit(lambda x: x)(tensor)
-    if self.dtype is not None and result.dtype != self.dtype:
-      raise TypeError(
-          "Backend '{}' cannot convert tensor of dtype {} to dtype {}".format(
-              self.name, result.dtype, self.dtype))
     return result
 
   def concat(self, values: Tensor, axis: int) -> Tensor:
@@ -54,8 +50,7 @@ class JaxBackend(numpy_backend.NumPyBackend):
       seed = np.random.randint(0, 2**63)
     key = self.jax.random.PRNGKey(seed)
 
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else np.dtype(np.float64)
+    dtype = dtype if dtype is not None else np.dtype(np.float64)
 
     def cmplx_randn(complex_dtype, real_dtype):
       real_dtype = np.dtype(real_dtype)
@@ -70,22 +65,22 @@ class JaxBackend(numpy_backend.NumPyBackend):
           if complex_dtype == np.dtype(np.complex64) else np.complex128(1j))
       return real_part + unit * complex_part
 
-    if dtype is np.dtype(self.np.complex128):
+    if np.dtype(dtype) is np.dtype(self.np.complex128):
       return cmplx_randn(dtype, self.np.float64)
-    if dtype is np.dtype(self.np.complex64):
+    if np.dtype(dtype) is np.dtype(self.np.complex64):
       return cmplx_randn(dtype, self.np.float32)
 
     return self.jax.random.normal(key, shape).astype(dtype)
 
-  def eigsh_lanczos(
-      self,
-      A: Callable,
-      initial_state: Optional[Tensor] = None,
-      ncv: Optional[int] = 200,
-      numeig: Optional[int] = 1,
-      tol: Optional[float] = 1E-8,
-      delta: Optional[float] = 1E-8,
-      ndiag: Optional[int] = 20,
-      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
+  def eigsh_lanczos(self,
+                    A: Callable,
+                    initial_state: Optional[Tensor] = None,
+                    ncv: Optional[int] = 200,
+                    numeig: Optional[int] = 1,
+                    tol: Optional[float] = 1E-8,
+                    delta: Optional[float] = 1E-8,
+                    ndiag: Optional[int] = 20,
+                    reorthogonalize: Optional[bool] = False
+                   ) -> Tuple[List, List]:
     raise NotImplementedError(
         "Backend '{}' has not implemented eighs_lanczos.".format(self.name))

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -10,17 +10,6 @@ np_randn_dtypes = [np.float32, np.float16, np.float64]
 np_dtypes = np_randn_dtypes + [np.complex64, np.complex128]
 
 
-@pytest.mark.parametrize("dtype", np_dtypes)
-def test_dtype(dtype):
-  backend = jax_backend.JaxBackend(dtype)
-  assert backend.dtype == np.dtype(dtype)
-  assert isinstance(backend.dtype, np.dtype)
-
-  backend = jax_backend.JaxBackend(np.dtype(dtype))
-  assert backend.dtype == np.dtype(dtype)
-  assert isinstance(backend.dtype, np.dtype)
-
-
 def test_tensordot():
   backend = jax_backend.JaxBackend()
   a = backend.convert_to_tensor(2 * np.ones((2, 3, 4)))
@@ -146,119 +135,80 @@ def test_norm():
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_eye(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.eye(N=4, M=5)
+  backend = jax_backend.JaxBackend()
+  a = backend.eye(N=4, M=5, dtype=dtype)
   np.testing.assert_allclose(np.eye(N=4, M=5, dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_ones(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.ones((4, 4))
+  backend = jax_backend.JaxBackend()
+  a = backend.ones((4, 4), dtype=dtype)
   np.testing.assert_allclose(np.ones((4, 4), dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_zeros(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.zeros((4, 4))
+  backend = jax_backend.JaxBackend()
+  a = backend.zeros((4, 4), dtype=dtype)
   np.testing.assert_allclose(np.zeros((4, 4), dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", np_randn_dtypes)
 def test_randn(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = jax_backend.JaxBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert a.shape == (4, 4)
 
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
 def test_randn_non_zero_imag(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = jax_backend.JaxBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert np.linalg.norm(np.imag(a)) != 0.0
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_eye_dtype(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  dtype_2 = np.float32
-  a = backend.eye(N=4, M=4, dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = jax_backend.JaxBackend()
+  a = backend.eye(N=4, M=4, dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_ones_dtype(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  dtype_2 = np.float32
-  a = backend.ones((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = jax_backend.JaxBackend()
+  a = backend.ones((4, 4), dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_zeros_dtype(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  dtype_2 = np.float32
-  a = backend.zeros((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = jax_backend.JaxBackend()
+  a = backend.zeros((4, 4), dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", np_randn_dtypes)
 def test_randn_dtype(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  dtype_2 = np.float32
-  a = backend.randn((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
-
-
-@pytest.mark.parametrize("dtype", np_dtypes)
-def test_eye_dtype_2(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.eye(N=4, M=4)
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", np_dtypes)
-def test_ones_dtype_2(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.ones((4, 4))
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", np_dtypes)
-def test_zeros_dtype_2(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.zeros((4, 4))
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", np_randn_dtypes)
-def test_randn_dtype_2(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = jax_backend.JaxBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", np_randn_dtypes)
 def test_randn_seed(dtype):
-  backend = jax_backend.JaxBackend(dtype=dtype)
-  a = backend.randn((4, 4), seed=10)
-  b = backend.randn((4, 4), seed=10)
+  backend = jax_backend.JaxBackend()
+  a = backend.randn((4, 4), seed=10, dtype=dtype)
+  b = backend.randn((4, 4), seed=10, dtype=dtype)
   np.testing.assert_allclose(a, b)
 
 
 def test_conj():
-  backend = jax_backend.JaxBackend(np.complex128)
+  backend = jax_backend.JaxBackend()
   real = np.random.rand(2, 2, 2)
   imag = np.random.rand(2, 2, 2)
   a = backend.convert_to_tensor(real + 1j * imag)
   actual = backend.conj(a)
   expected = real - 1j * imag
   np.testing.assert_allclose(expected, actual)
-
-
-def test_backend_dtype_exception():
-  backend = jax_backend.JaxBackend(dtype=np.float32)
-  tensor = np.random.rand(2, 2, 2)
-  with pytest.raises(TypeError):
-    _ = backend.convert_to_tensor(tensor)

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -22,11 +22,10 @@ Tensor = Any
 class NumPyBackend(base_backend.BaseBackend):
   """See base_backend.BaseBackend for documentation."""
 
-  def __init__(self, dtype: Optional[numpy.dtype] = None):
+  def __init__(self):
     super(NumPyBackend, self).__init__()
     self.np = numpy
     self.name = "numpy"
-    self._dtype = self.np.dtype(dtype) if dtype is not None else None
 
   def tensordot(self, a: Tensor, b: Tensor, axes: Sequence[Sequence[int]]):
     return self.np.tensordot(a, b, axes)
@@ -43,8 +42,9 @@ class NumPyBackend(base_backend.BaseBackend):
                         max_singular_values: Optional[int] = None,
                         max_truncation_error: Optional[float] = None
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
-    return decompositions.svd_decomposition(
-        self.np, tensor, split_axis, max_singular_values, max_truncation_error)
+    return decompositions.svd_decomposition(self.np, tensor, split_axis,
+                                            max_singular_values,
+                                            max_truncation_error)
 
   def qr_decomposition(
       self,
@@ -86,10 +86,6 @@ class NumPyBackend(base_backend.BaseBackend):
       raise TypeError("Expected a `np.array` or scalar. Got {}".format(
           type(tensor)))
     result = self.np.asarray(tensor)
-    if self.dtype is not None and self.np.dtype(result.dtype) != self.dtype:
-      raise TypeError(
-          "Backend '{}' cannot convert tensor of dtype {} to dtype {}".format(
-              self.name, result.dtype, numpy.dtype(self.dtype)))
     return result
 
   def trace(self, tensor: Tensor) -> Tensor:
@@ -107,23 +103,18 @@ class NumPyBackend(base_backend.BaseBackend):
 
   def eye(self, N, dtype: Optional[numpy.dtype] = None,
           M: Optional[int] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.np.float64
+    dtype = dtype if dtype is not None else self.np.float64
 
     return self.np.eye(N, M=M, dtype=dtype)
 
   def ones(self, shape: Tuple[int, ...],
            dtype: Optional[numpy.dtype] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.np.float64
-
+    dtype = dtype if dtype is not None else self.np.float64
     return self.np.ones(shape, dtype=dtype)
 
   def zeros(self, shape: Tuple[int, ...],
             dtype: Optional[numpy.dtype] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.np.float64
-
+    dtype = dtype if dtype is not None else self.np.float64
     return self.np.zeros(shape, dtype=dtype)
 
   def randn(self,
@@ -133,12 +124,7 @@ class NumPyBackend(base_backend.BaseBackend):
 
     if seed:
       self.np.random.seed(seed)
-
-    if not dtype:
-      dtype = (
-          self.dtype
-          if self.dtype is not None else self.np.dtype(self.np.float64))
-
+    dtype = dtype if dtype is not None else self.np.float64
     if ((dtype is self.np.dtype(self.np.complex128)) or
         (dtype is self.np.dtype(self.np.complex64))):
       return self.np.random.randn(*shape).astype(
@@ -148,16 +134,16 @@ class NumPyBackend(base_backend.BaseBackend):
   def conj(self, tensor: Tensor) -> Tensor:
     return self.np.conj(tensor)
 
-  def eigsh_lanczos(
-      self,
-      A: Callable,
-      initial_state: Optional[Tensor] = None,
-      ncv: Optional[int] = 200,
-      numeig: Optional[int] = 1,
-      tol: Optional[float] = 1E-8,
-      delta: Optional[float] = 1E-8,
-      ndiag: Optional[int] = 20,
-      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
+  def eigsh_lanczos(self,
+                    A: Callable,
+                    initial_state: Optional[Tensor] = None,
+                    ncv: Optional[int] = 200,
+                    numeig: Optional[int] = 1,
+                    tol: Optional[float] = 1E-8,
+                    delta: Optional[float] = 1E-8,
+                    ndiag: Optional[int] = 20,
+                    reorthogonalize: Optional[bool] = False
+                   ) -> Tuple[List, List]:
     """
     Lanczos method for finding the lowest eigenvector-eigenvalue pairs
     of a `LinearOperator` `A`.

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -125,8 +125,8 @@ class NumPyBackend(base_backend.BaseBackend):
     if seed:
       self.np.random.seed(seed)
     dtype = dtype if dtype is not None else self.np.float64
-    if ((dtype is self.np.dtype(self.np.complex128)) or
-        (dtype is self.np.dtype(self.np.complex64))):
+    if ((self.np.dtype(dtype) is self.np.dtype(self.np.complex128)) or
+        (self.np.dtype(dtype) is self.np.dtype(self.np.complex64))):
       return self.np.random.randn(*shape).astype(
           dtype) + 1j * self.np.random.randn(*shape).astype(dtype)
     return self.np.random.randn(*shape).astype(dtype)
@@ -189,7 +189,13 @@ class NumPyBackend(base_backend.BaseBackend):
       if not hasattr(A, 'shape'):
         raise AttributeError("`A` has no  attribute `shape`. Cannot initialize "
                              "lanczos. Please provide a valid `initial_state`")
-      initial_state = self.randn(A.shape[1])
+      if not hasattr(A, 'dtype'):
+        raise AttributeError(
+            "`A` has no  attribute `dtype`. Cannot initialize "
+            "lanczos. Please provide a valid `initial_state` with "
+            "a `dtype` attribute")
+
+      initial_state = self.randn(A.shape[1], A.dtype)
     if not isinstance(initial_state, self.np.ndarray):
       raise TypeError("Expected a `np.array`. Got {}".format(
           type(initial_state)))
@@ -247,7 +253,7 @@ class NumPyBackend(base_backend.BaseBackend):
       eigvals = self.np.array(eigvals).astype(A_tridiag.dtype)
 
     for n2 in range(min(numeig, len(eigvals))):
-      state = self.zeros(initial_state.shape)
+      state = self.zeros(initial_state.shape, initial_state.dtype)
       for n1, vec in enumerate(krylov_vecs):
         state += vec * u[n1, n2]
       eigenvectors.append(state / self.np.linalg.norm(state))

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -8,17 +8,6 @@ np_randn_dtypes = [np.float32, np.float16, np.float64]
 np_dtypes = np_randn_dtypes + [np.complex64, np.complex128]
 
 
-@pytest.mark.parametrize("dtype", np_dtypes)
-def test_dtype(dtype):
-  backend = numpy_backend.NumPyBackend(dtype)
-  assert backend.dtype == np.dtype(dtype)
-  assert isinstance(backend.dtype, np.dtype)
-
-  backend = numpy_backend.NumPyBackend(np.dtype(dtype))
-  assert backend.dtype == np.dtype(dtype)
-  assert isinstance(backend.dtype, np.dtype)
-
-
 def test_tensordot():
   backend = numpy_backend.NumPyBackend()
   a = backend.convert_to_tensor(2 * np.ones((2, 3, 4)))
@@ -144,109 +133,77 @@ def test_norm():
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_eye(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.eye(N=4, M=5)
+  backend = numpy_backend.NumPyBackend()
+  a = backend.eye(N=4, M=5, dtype=dtype)
   np.testing.assert_allclose(np.eye(N=4, M=5, dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_ones(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.ones((4, 4))
+  backend = numpy_backend.NumPyBackend()
+  a = backend.ones((4, 4), dtype=dtype)
   np.testing.assert_allclose(np.ones((4, 4), dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_zeros(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.zeros((4, 4))
+  backend = numpy_backend.NumPyBackend()
+  a = backend.zeros((4, 4), dtype=dtype)
   np.testing.assert_allclose(np.zeros((4, 4), dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", np_randn_dtypes)
 def test_randn(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = numpy_backend.NumPyBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert a.shape == (4, 4)
 
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
 def test_randn_non_zero_imag(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = numpy_backend.NumPyBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert np.linalg.norm(np.imag(a)) != 0.0
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_eye_dtype(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  dtype_2 = np.float32
-  a = backend.eye(N=4, M=4, dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = numpy_backend.NumPyBackend()
+  a = backend.eye(N=4, M=4, dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_ones_dtype(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  dtype_2 = np.float32
-  a = backend.ones((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = numpy_backend.NumPyBackend()
+  a = backend.ones((4, 4), dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", np_dtypes)
 def test_zeros_dtype(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  dtype_2 = np.float32
-  a = backend.zeros((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = numpy_backend.NumPyBackend()
+  a = backend.zeros((4, 4), dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", np_randn_dtypes)
 def test_randn_dtype(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  dtype_2 = np.float32
-  a = backend.randn((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
-
-
-@pytest.mark.parametrize("dtype", np_dtypes)
-def test_eye_dtype_2(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.eye(N=4, M=4)
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", np_dtypes)
-def test_ones_dtype_2(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.ones((4, 4))
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", np_dtypes)
-def test_zeros_dtype_2(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.zeros((4, 4))
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", np_randn_dtypes)
-def test_randn_dtype_2(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = numpy_backend.NumPyBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", np_randn_dtypes)
 def test_randn_seed(dtype):
-  backend = numpy_backend.NumPyBackend(dtype=dtype)
-  a = backend.randn((4, 4), seed=10)
-  b = backend.randn((4, 4), seed=10)
+  backend = numpy_backend.NumPyBackend()
+  a = backend.randn((4, 4), seed=10, dtype=dtype)
+  b = backend.randn((4, 4), seed=10, dtype=dtype)
   np.testing.assert_allclose(a, b)
 
 
 def test_conj():
-  backend = numpy_backend.NumPyBackend(np.complex128)
+  backend = numpy_backend.NumPyBackend()
   real = np.random.rand(2, 2, 2)
   imag = np.random.rand(2, 2, 2)
   a = backend.convert_to_tensor(real + 1j * imag)
@@ -255,20 +212,13 @@ def test_conj():
   np.testing.assert_allclose(expected, actual)
 
 
-def test_backend_dtype_exception():
-  backend = numpy_backend.NumPyBackend(dtype=np.float32)
-  tensor = np.random.rand(2, 2, 2)
-  with pytest.raises(TypeError):
-    _ = backend.convert_to_tensor(tensor)
-
-
 @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
 def test_eigsh_lanczos_1(dtype):
-  backend = numpy_backend.NumPyBackend(dtype)
+  backend = numpy_backend.NumPyBackend()
   D = 16
   np.random.seed(10)
-  init = backend.randn((D,))
-  tmp = backend.randn((D, D))
+  init = backend.randn((D,), dtype=dtype)
+  tmp = backend.randn((D, D), dtype=dtype)
   H = tmp + backend.transpose(backend.conj(tmp), (1, 0))
 
   def mv(x):
@@ -286,21 +236,22 @@ def test_eigsh_lanczos_1(dtype):
 
 @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
 def test_eigsh_lanczos_2(dtype):
-  backend = numpy_backend.NumPyBackend(dtype)
+  backend = numpy_backend.NumPyBackend()
   D = 16
   np.random.seed(10)
-  tmp = backend.randn((D, D))
+  tmp = backend.randn((D, D), dtype=dtype)
   H = tmp + backend.transpose(backend.conj(tmp), (1, 0))
 
   class LinearOperator:
 
-    def __init__(self, shape):
+    def __init__(self, shape, dtype):
       self.shape = shape
+      self.dtype = dtype
 
     def __call__(self, x):
       return np.dot(H, x)
 
-  mv = LinearOperator(((D,), (D,)))
+  mv = LinearOperator(shape=((D,), (D,)), dtype=dtype)
   eta1, U1 = backend.eigsh_lanczos(mv)
   eta2, U2 = np.linalg.eigh(H)
   v2 = U2[:, 0]
@@ -313,7 +264,7 @@ def test_eigsh_lanczos_2(dtype):
 
 def test_eigsh_lanczos_raises():
   dtype = np.float64
-  backend = numpy_backend.NumPyBackend(dtype)
+  backend = numpy_backend.NumPyBackend()
   with pytest.raises(AttributeError):
     backend.eigsh_lanczos(lambda x: x)
   with pytest.raises(ValueError):
@@ -322,14 +273,10 @@ def test_eigsh_lanczos_raises():
     backend.eigsh_lanczos(lambda x: x, numeig=2, reorthogonalize=False)
 
 
-@pytest.mark.parametrize("a, b, expected",
-                         [pytest.param(np.ones((1, 2, 3)),
-                                       np.ones((1, 2, 3)),
-                                       np.ones((1, 2, 3))),
-                          pytest.param(2. * np.ones(()),
-                                       np.ones((1, 2, 3)),
-                                       2. * np.ones((1, 2, 3))),
-                         ])
+@pytest.mark.parametrize("a, b, expected", [
+    pytest.param(np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 3))),
+    pytest.param(2. * np.ones(()), np.ones((1, 2, 3)), 2. * np.ones((1, 2, 3))),
+])
 def test_multiply(a, b, expected):
   backend = numpy_backend.NumPyBackend()
   tensor1 = backend.convert_to_tensor(a)

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -263,7 +263,6 @@ def test_eigsh_lanczos_2(dtype):
 
 
 def test_eigsh_lanczos_raises():
-  dtype = np.float64
   backend = numpy_backend.NumPyBackend()
   with pytest.raises(AttributeError):
     backend.eigsh_lanczos(lambda x: x)

--- a/tensornetwork/backends/pytorch/pytorch_backend.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend.py
@@ -25,7 +25,7 @@ Tensor = Any
 class PyTorchBackend(base_backend.BaseBackend):
   """See base_backend.BaseBackend for documentation."""
 
-  def __init__(self, dtype: Optional[Any] = None):
+  def __init__(self):
     super(PyTorchBackend, self).__init__()
     try:
       #pylint: disable=import-outside-toplevel
@@ -35,7 +35,6 @@ class PyTorchBackend(base_backend.BaseBackend):
                         "backend or install PyTorch.")
     self.torch = torch
     self.name = "pytorch"
-    self._dtype = dtype
 
   def tensordot(self, a: Tensor, b: Tensor, axes: Sequence[Sequence[int]]):
     return self.torch.tensordot(a, b, dims=axes)
@@ -90,10 +89,6 @@ class PyTorchBackend(base_backend.BaseBackend):
 
   def convert_to_tensor(self, tensor: Tensor) -> Tensor:
     result = self.torch.as_tensor(tensor)
-    if self.dtype is not None and result.dtype is not self.dtype:
-      raise TypeError(
-          "Backend '{}' cannot convert tensor of dtype {} to dtype {}".format(
-              self.name, result.dtype, self.dtype))
     return result
 
   def trace(self, tensor: Tensor) -> Tensor:
@@ -110,21 +105,18 @@ class PyTorchBackend(base_backend.BaseBackend):
 
   def eye(self, N: int, dtype: Optional[Any] = None,
           M: Optional[int] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.torch.float64
+    dtype = dtype if dtype is not None else self.torch.float64
     if not M:
       M = N  #torch crashes if one passes M = None with dtype!=None
     return self.torch.eye(n=N, m=M, dtype=dtype)
 
   def ones(self, shape: Tuple[int, ...], dtype: Optional[Any] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.torch.float64
+    dtype = dtype if dtype is not None else self.torch.float64
     return self.torch.ones(shape, dtype=dtype)
 
   def zeros(self, shape: Tuple[int, ...],
             dtype: Optional[Any] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.torch.float64
+    dtype = dtype if dtype is not None else self.torch.float64
     return self.torch.zeros(shape, dtype=dtype)
 
   def randn(self,
@@ -133,25 +125,22 @@ class PyTorchBackend(base_backend.BaseBackend):
             seed: Optional[int] = None) -> Tensor:
     if seed:
       self.torch.manual_seed(seed)
-
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.torch.float64
-
+    dtype = dtype if dtype is not None else self.torch.float64
     return self.torch.randn(shape, dtype=dtype)
 
   def conj(self, tensor: Tensor) -> Tensor:
     return tensor  #pytorch does not support complex dtypes
 
-  def eigsh_lanczos(
-      self,
-      A: Callable,
-      initial_state: Optional[Tensor] = None,
-      ncv: Optional[int] = 200,
-      numeig: Optional[int] = 1,
-      tol: Optional[float] = 1E-8,
-      delta: Optional[float] = 1E-8,
-      ndiag: Optional[int] = 20,
-      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
+  def eigsh_lanczos(self,
+                    A: Callable,
+                    initial_state: Optional[Tensor] = None,
+                    ncv: Optional[int] = 200,
+                    numeig: Optional[int] = 1,
+                    tol: Optional[float] = 1E-8,
+                    delta: Optional[float] = 1E-8,
+                    ndiag: Optional[int] = 20,
+                    reorthogonalize: Optional[bool] = False
+                   ) -> Tuple[List, List]:
     """
     Lanczos method for finding the lowest eigenvector-eigenvalue pairs
     of a `LinearOperator` `A`.
@@ -192,12 +181,17 @@ class PyTorchBackend(base_backend.BaseBackend):
         raise ValueError(
             "A.shape[1]={} and initial_state.shape={} are incompatible.".format(
                 A.shape[1], initial_state.shape))
-
     if initial_state is None:
       if not hasattr(A, 'shape'):
         raise AttributeError("`A` has no  attribute `shape`. Cannot initialize "
                              "lanczos. Please provide a valid `initial_state`")
-      initial_state = self.randn(A.shape[1])
+
+      if not hasattr(A, 'dtype'):
+        raise AttributeError(
+            "`A` has no  attribute `dtype`. Cannot initialize "
+            "lanczos. Please provide a valid `initial_state` with "
+            "a `dtype` attribute")
+      initial_state = self.randn(A.shape[1], A.dtype)
     else:
       initial_state = self.convert_to_tensor(initial_state)
     vector_n = initial_state
@@ -249,7 +243,7 @@ class PyTorchBackend(base_backend.BaseBackend):
     eigvals, u = A_tridiag.symeig()
     eigenvectors = []
     for n2 in range(min(numeig, len(eigvals))):
-      state = self.zeros(initial_state.shape)
+      state = self.zeros(initial_state.shape, initial_state.dtype)
       for n1, vec in enumerate(krylov_vecs):
         state += vec * u[n1, n2]
       eigenvectors.append(state / self.torch.norm(state))

--- a/tensornetwork/backends/pytorch/pytorch_backend_test.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend_test.py
@@ -228,7 +228,7 @@ def test_eigsh_lanczos_2():
       self.dtype = dtype
 
     def __call__(self, x):
-      return np.dot(H, x)
+      return H.mv(x)
 
   mv = LinearOperator(shape=((D,), (D,)), dtype=dtype)
   eta1, U1 = backend.eigsh_lanczos(mv)

--- a/tensornetwork/backends/pytorch/pytorch_backend_test.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend_test.py
@@ -242,7 +242,6 @@ def test_eigsh_lanczos_2():
 
 
 def test_eigsh_lanczos_raises():
-  dtype = torch.float64
   backend = pytorch_backend.PyTorchBackend()
   with pytest.raises(AttributeError):
     backend.eigsh_lanczos(lambda x: x)

--- a/tensornetwork/backends/pytorch/pytorch_backend_test.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend_test.py
@@ -122,104 +122,65 @@ def test_norm():
 
 @pytest.mark.parametrize("dtype", torch_eye_dtypes)
 def test_eye(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.eye(N=4, M=5)
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.eye(N=4, M=5, dtype=dtype)
   np.testing.assert_allclose(torch.eye(n=4, m=5, dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", torch_dtypes)
 def test_ones(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.ones((4, 4))
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.ones((4, 4), dtype=dtype)
   np.testing.assert_allclose(torch.ones((4, 4), dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", torch_dtypes)
 def test_zeros(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.zeros((4, 4))
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.zeros((4, 4), dtype=dtype)
   np.testing.assert_allclose(torch.zeros((4, 4), dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", torch_randn_dtypes)
 def test_randn(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert a.shape == (4, 4)
 
 
 @pytest.mark.parametrize("dtype", torch_eye_dtypes)
 def test_eye_dtype(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  dtype_2 = torch.float32
-  a = backend.eye(N=4, M=4, dtype=dtype_2)
-  assert a.dtype == dtype_2
-
-
-@pytest.mark.parametrize("dtype", torch_eye_dtypes)
-def test_eye_two_args(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  dtype_2 = torch.float32
-  _ = backend.eye(N=4, dtype=dtype_2)  # a check
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.eye(N=4, M=4, dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", torch_dtypes)
 def test_ones_dtype(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  dtype_2 = torch.float32
-  a = backend.ones((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.ones((4, 4), dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", torch_dtypes)
 def test_zeros_dtype(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  dtype_2 = torch.float32
-  a = backend.zeros((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.zeros((4, 4), dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", torch_randn_dtypes)
 def test_randn_dtype(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  dtype_2 = torch.float32
-  a = backend.randn((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
-
-
-@pytest.mark.parametrize("dtype", torch_eye_dtypes)
-def test_eye_dtype_2(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.eye(N=4, M=4)
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", torch_dtypes)
-def test_ones_dtype_2(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.ones((4, 4))
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", torch_dtypes)
-def test_zeros_dtype_2(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.zeros((4, 4))
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", torch_randn_dtypes)
-def test_randn_dtype_2(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", torch_randn_dtypes)
 def test_randn_seed(dtype):
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
-  a = backend.randn((4, 4), seed=10)
-  b = backend.randn((4, 4), seed=10)
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.randn((4, 4), seed=10, dtype=dtype)
+  b = backend.randn((4, 4), seed=10, dtype=dtype)
   np.testing.assert_allclose(a, b)
 
 
@@ -232,19 +193,12 @@ def test_conj():
   np.testing.assert_allclose(expected, actual)
 
 
-def test_backend_dtype_exception():
-  backend = pytorch_backend.PyTorchBackend(dtype=torch.float32)
-  tensor = np.random.rand(2, 2, 2)
-  with pytest.raises(TypeError):
-    _ = backend.convert_to_tensor(tensor)
-
-
 def test_eigsh_lanczos_1():
   dtype = torch.float64
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
+  backend = pytorch_backend.PyTorchBackend()
   D = 16
-  init = backend.randn((D,))
-  tmp = backend.randn((D, D))
+  init = backend.randn((D,), dtype=dtype)
+  tmp = backend.randn((D, D), dtype=dtype)
   H = tmp + backend.transpose(backend.conj(tmp), (1, 0))
 
   def mv(x):
@@ -262,20 +216,21 @@ def test_eigsh_lanczos_1():
 
 def test_eigsh_lanczos_2():
   dtype = torch.float64
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
+  backend = pytorch_backend.PyTorchBackend()
   D = 16
-  tmp = backend.randn((D, D))
+  tmp = backend.randn((D, D), dtype=dtype)
   H = tmp + backend.transpose(backend.conj(tmp), (1, 0))
 
   class LinearOperator:
 
-    def __init__(self, shape):
+    def __init__(self, shape, dtype):
       self.shape = shape
+      self.dtype = dtype
 
     def __call__(self, x):
-      return H.mv(x)
+      return np.dot(H, x)
 
-  mv = LinearOperator(((D,), (D,)))
+  mv = LinearOperator(shape=((D,), (D,)), dtype=dtype)
   eta1, U1 = backend.eigsh_lanczos(mv)
   eta2, U2 = H.symeig()
   v2 = U2[:, 0]
@@ -288,7 +243,7 @@ def test_eigsh_lanczos_2():
 
 def test_eigsh_lanczos_raises():
   dtype = torch.float64
-  backend = pytorch_backend.PyTorchBackend(dtype=dtype)
+  backend = pytorch_backend.PyTorchBackend()
   with pytest.raises(AttributeError):
     backend.eigsh_lanczos(lambda x: x)
   with pytest.raises(ValueError):
@@ -297,14 +252,10 @@ def test_eigsh_lanczos_raises():
     backend.eigsh_lanczos(lambda x: x, numeig=2, reorthogonalize=False)
 
 
-@pytest.mark.parametrize("a, b, expected",
-                         [pytest.param(np.ones((1, 2, 3)),
-                                       np.ones((1, 2, 3)),
-                                       np.ones((1, 2, 3))),
-                          pytest.param(2. * np.ones(()),
-                                       np.ones((1, 2, 3)),
-                                       2. * np.ones((1, 2, 3))),
-                          ])
+@pytest.mark.parametrize("a, b, expected", [
+    pytest.param(np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 3))),
+    pytest.param(2. * np.ones(()), np.ones((1, 2, 3)), 2. * np.ones((1, 2, 3))),
+])
 def test_multiply(a, b, expected):
   backend = pytorch_backend.PyTorchBackend()
   tensor1 = backend.convert_to_tensor(a)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -26,7 +26,7 @@ Tensor = Any
 class TensorFlowBackend(base_backend.BaseBackend):
   """See base_backend.BaseBackend for documentation."""
 
-  def __init__(self, dtype: Optional[Type[np.number]] = None):
+  def __init__(self):
     super(TensorFlowBackend, self).__init__()
     try:
       #pylint: disable=import-outside-toplevel
@@ -36,7 +36,6 @@ class TensorFlowBackend(base_backend.BaseBackend):
                         "different backend or install Tensorflow.")
     self.tf = tf
     self.name = "tensorflow"
-    self._dtype = dtype
 
   def tensordot(self, a: Tensor, b: Tensor, axes: Sequence[Sequence[int]]):
     return tensordot2.tensordot(self.tf, a, b, axes)
@@ -53,8 +52,9 @@ class TensorFlowBackend(base_backend.BaseBackend):
                         max_singular_values: Optional[int] = None,
                         max_truncation_error: Optional[float] = None
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
-    return decompositions.svd_decomposition(
-        self.tf, tensor, split_axis, max_singular_values, max_truncation_error)
+    return decompositions.svd_decomposition(self.tf, tensor, split_axis,
+                                            max_singular_values,
+                                            max_truncation_error)
 
   def qr_decomposition(self, tensor: Tensor,
                        split_axis: int) -> Tuple[Tensor, Tensor]:
@@ -84,10 +84,6 @@ class TensorFlowBackend(base_backend.BaseBackend):
 
   def convert_to_tensor(self, tensor: Tensor) -> Tensor:
     result = self.tf.convert_to_tensor(tensor)
-    if self.dtype is not None and result.dtype is not self.dtype:
-      raise TypeError(
-          "Backend '{}' cannot convert tensor of dtype {} to dtype {}".format(
-              self.name, result.dtype, self.dtype))
     return result
 
   def trace(self, tensor: Tensor) -> Tensor:
@@ -106,24 +102,19 @@ class TensorFlowBackend(base_backend.BaseBackend):
           N: int,
           dtype: Optional[Type[np.number]] = None,
           M: Optional[int] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.tf.float64
+    dtype = dtype if dtype is not None else self.tf.float64
     return self.tf.eye(num_rows=N, num_columns=M, dtype=dtype)
 
   def ones(self,
            shape: Tuple[int, ...],
            dtype: Optional[Type[np.number]] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.tf.float64
-
+    dtype = dtype if dtype is not None else self.tf.float64
     return self.tf.ones(shape=shape, dtype=dtype)
 
   def zeros(self,
             shape: Tuple[int, ...],
             dtype: Optional[Type[np.number]] = None) -> Tensor:
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.tf.float64
-
+    dtype = dtype if dtype is not None else self.tf.float64
     return self.tf.zeros(shape, dtype=dtype)
 
   def randn(self,
@@ -133,9 +124,7 @@ class TensorFlowBackend(base_backend.BaseBackend):
     if seed:
       self.tf.random.set_seed(seed)
 
-    if not dtype:
-      dtype = self.dtype if self.dtype is not None else self.tf.float64
-
+    dtype = dtype if dtype is not None else self.tf.float64
     if (dtype is self.tf.complex128) or (dtype is self.tf.complex64):
       return self.tf.complex(
           self.tf.random.normal(shape=shape, dtype=dtype.real_dtype),
@@ -145,16 +134,16 @@ class TensorFlowBackend(base_backend.BaseBackend):
   def conj(self, tensor: Tensor) -> Tensor:
     return self.tf.math.conj(tensor)
 
-  def eigsh_lanczos(
-      self,
-      A: Callable,
-      initial_state: Optional[Tensor] = None,
-      ncv: Optional[int] = 200,
-      numeig: Optional[int] = 1,
-      tol: Optional[float] = 1E-8,
-      delta: Optional[float] = 1E-8,
-      ndiag: Optional[int] = 20,
-      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
+  def eigsh_lanczos(self,
+                    A: Callable,
+                    initial_state: Optional[Tensor] = None,
+                    ncv: Optional[int] = 200,
+                    numeig: Optional[int] = 1,
+                    tol: Optional[float] = 1E-8,
+                    delta: Optional[float] = 1E-8,
+                    ndiag: Optional[int] = 20,
+                    reorthogonalize: Optional[bool] = False
+                   ) -> Tuple[List, List]:
     raise NotImplementedError(
         "Backend '{}' has not implemented eighs_lanczos.".format(self.name))
 

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -189,8 +189,8 @@ def test_randn_dtype(dtype):
 @pytest.mark.parametrize("dtype", tf_randn_dtypes)
 def test_randn_seed(dtype):
   backend = tensorflow_backend.TensorFlowBackend()
-  a = backend.randn((4, 4), seed=10)
-  b = backend.randn((4, 4), seed=10)
+  a = backend.randn((4, 4), seed=10, dtype=dtype)
+  b = backend.randn((4, 4), seed=10, dtype=dtype)
   np.testing.assert_allclose(a, b)
 
 

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -5,9 +5,9 @@ import tensorflow as tf
 import pytest
 from tensornetwork.backends.tensorflow import tensorflow_backend
 
-
 tf_randn_dtypes = [tf.float32, tf.float16, tf.float64]
 tf_dtypes = tf_randn_dtypes + [tf.complex128, tf.complex64]
+
 
 def test_tensordot():
   backend = tensorflow_backend.TensorFlowBackend()
@@ -125,109 +125,77 @@ def test_norm():
 
 @pytest.mark.parametrize("dtype", tf_dtypes)
 def test_eye(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.eye(N=4, M=5)
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.eye(N=4, M=5, dtype=dtype)
   np.testing.assert_allclose(tf.eye(num_rows=4, num_columns=5, dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", tf_dtypes)
 def test_ones(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.ones((4, 4))
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.ones((4, 4), dtype=dtype)
   np.testing.assert_allclose(tf.ones((4, 4), dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", tf_dtypes)
 def test_zeros(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.zeros((4, 4))
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.zeros((4, 4), dtype=dtype)
   np.testing.assert_allclose(tf.zeros((4, 4), dtype=dtype), a)
 
 
 @pytest.mark.parametrize("dtype", tf_randn_dtypes)
 def test_randn(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert a.shape == (4, 4)
 
 
 @pytest.mark.parametrize("dtype", [tf.complex64, tf.complex128])
 def test_randn_non_zero_imag(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert tf.math.greater(tf.linalg.norm(tf.math.imag(a)), 0.0)
 
 
 @pytest.mark.parametrize("dtype", tf_dtypes)
 def test_eye_dtype(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  dtype_2 = tf.float32
-  a = backend.eye(N=4, M=4, dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.eye(N=4, M=4, dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", tf_dtypes)
 def test_ones_dtype(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  dtype_2 = tf.float32
-  a = backend.ones((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.ones((4, 4), dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", tf_dtypes)
 def test_zeros_dtype(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  dtype_2 = tf.float32
-  a = backend.zeros((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.zeros((4, 4), dtype=dtype)
+  assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", tf_randn_dtypes)
 def test_randn_dtype(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  dtype_2 = tf.float32
-  a = backend.randn((4, 4), dtype=dtype_2)
-  assert a.dtype == dtype_2
-
-
-@pytest.mark.parametrize("dtype", tf_dtypes)
-def test_eye_dtype_2(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.eye(N=4, M=4)
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", tf_dtypes)
-def test_ones_dtype_2(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.ones((4, 4))
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", tf_dtypes)
-def test_zeros_dtype_2(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.zeros((4, 4))
-  assert a.dtype == dtype
-
-
-@pytest.mark.parametrize("dtype", tf_randn_dtypes)
-def test_randn_dtype_2(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
-  a = backend.randn((4, 4))
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.randn((4, 4), dtype=dtype)
   assert a.dtype == dtype
 
 
 @pytest.mark.parametrize("dtype", tf_randn_dtypes)
 def test_randn_seed(dtype):
-  backend = tensorflow_backend.TensorFlowBackend(dtype=dtype)
+  backend = tensorflow_backend.TensorFlowBackend()
   a = backend.randn((4, 4), seed=10)
   b = backend.randn((4, 4), seed=10)
   np.testing.assert_allclose(a, b)
 
 
 def test_conj():
-  backend = tensorflow_backend.TensorFlowBackend(dtype=tf.complex128)
+  backend = tensorflow_backend.TensorFlowBackend()
   real = np.random.rand(2, 2, 2)
   imag = np.random.rand(2, 2, 2)
   a = backend.convert_to_tensor(real + 1j * imag)
@@ -236,21 +204,10 @@ def test_conj():
   np.testing.assert_allclose(expected, actual)
 
 
-def test_backend_dtype_exception():
-  backend = tensorflow_backend.TensorFlowBackend(dtype=tf.float32)
-  tensor = np.random.rand(2, 2, 2)
-  with pytest.raises(TypeError):
-    _ = backend.convert_to_tensor(tensor)
-
-
-@pytest.mark.parametrize("a, b, expected",
-                         [pytest.param(np.ones((1, 2, 3)),
-                                       np.ones((1, 2, 3)),
-                                       np.ones((1, 2, 3))),
-                          pytest.param(2. * np.ones(()),
-                                       np.ones((1, 2, 3)),
-                                       2. * np.ones((1, 2, 3))),
-                          ])
+@pytest.mark.parametrize("a, b, expected", [
+    pytest.param(np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 3))),
+    pytest.param(2. * np.ones(()), np.ones((1, 2, 3)), 2. * np.ones((1, 2, 3))),
+])
 def test_multiply(a, b, expected):
   backend = tensorflow_backend.TensorFlowBackend()
   tensor1 = backend.convert_to_tensor(a)

--- a/tensornetwork/matrixproductstates/mps.py
+++ b/tensornetwork/matrixproductstates/mps.py
@@ -68,7 +68,9 @@ class BaseMPS:
     #tensors will be converted to backend type during
     #call to __init__
     be = backend_factory.get_backend(name='numpy')
-    tensors = [be.randn((D[n], d[n], D[n + 1])) for n in range(len(d))]
+    tensors = [
+        be.randn((D[n], d[n], D[n + 1]), dtype=dtype) for n in range(len(d))
+    ]
     cls(tensors=tensors, backend=backend)
     return cls
 

--- a/tensornetwork/matrixproductstates/mps.py
+++ b/tensornetwork/matrixproductstates/mps.py
@@ -67,7 +67,7 @@ class BaseMPS:
     #use numpy backend for tensor initialization.
     #tensors will be converted to backend type during
     #call to __init__
-    be = backend_factory.get_backend(name='numpy', dtype=dtype)
+    be = backend_factory.get_backend(name='numpy')
     tensors = [be.randn((D[n], d[n], D[n + 1])) for n in range(len(d))]
     cls(tensors=tensors, backend=backend)
     return cls
@@ -327,7 +327,7 @@ class BaseMPS:
 
         if n < n2:
           L = self.apply_transfer_operator(n % N, 'left', L)
-    return np.array(c)
+    return c
 
 
 class FiniteMPS(BaseMPS):
@@ -403,7 +403,7 @@ class FiniteMPS(BaseMPS):
       backend:L An optional backend.
     """
     #use numpy backend for tensor initialization
-    be = backend_factory.get_backend(name='numpy', dtype=dtype)
+    be = backend_factory.get_backend(name='numpy')
     if len(D) != len(d) - 1:
       raise ValueError('len(D) = {} is different from len(d) - 1 = {}'.format(
           len(D),
@@ -527,8 +527,8 @@ class FiniteMPS(BaseMPS):
       n1[1] ^ n2[1]
     result = n1 @ n2
     return self.backend.norm(
-        abs(result.tensor -
-            self.backend.eye(N=result.shape[0], M=result.shape[1])))
+        abs(result.tensor - self.backend.eye(
+            N=result.shape[0], M=result.shape[1], dtype=self.dtype)))
 
   def check_canonical(self) -> Tensor:
     """
@@ -576,7 +576,7 @@ class FiniteMPS(BaseMPS):
     left_envs = {}
     for site in left_sites:
       left_envs[site] = Node(
-          self.backend.eye(N=self.nodes[site].shape[0]),
+          self.backend.eye(N=self.nodes[site].shape[0], dtype=self.dtype),
           backend=self.backend.name)
 
     # left reduced density matrices at sites > center_position
@@ -642,7 +642,7 @@ class FiniteMPS(BaseMPS):
     right_envs = {}
     for site in right_sites:
       right_envs[site] = Node(
-          self.backend.eye(N=self.nodes[site].shape[2]),
+          self.backend.eye(N=self.nodes[site].shape[2], dtype=self.dtype),
           backend=self.backend.name)
 
     # right reduced density matrices at sites < center_position

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -98,9 +98,8 @@ class BaseNode(ABC):
 
   @property
   def dtype(self):
-    if self.backend:
-      return self.tensor.dtype
-    return None
+    #any derived instance of BaseNode always has to have a tensor
+    return self.tensor.dtype
 
   def set_signature(self, signature: int) -> None:
     """Set the signature for the node.
@@ -516,17 +515,14 @@ class Node(BaseNode):
       tensor = tensor.tensor
     if not backend:
       backend = config.default_backend
-    #use dtype=None here; the backend dtype will be deduced from the
-    #tensor dtype.
-    backend_obj = backend_factory.get_backend(backend, dtype=None)
+
+    backend_obj = backend_factory.get_backend(backend)
     self._tensor = backend_obj.convert_to_tensor(tensor)
     super().__init__(
         name=name,
         axis_names=axis_names,
         backend=backend_obj,
         shape=backend_obj.shape_tuple(self._tensor))
-    if self.backend and not self.backend.dtype:
-      self.backend.dtype = self._tensor.dtype
 
   def get_tensor(self):
     return self.tensor
@@ -606,9 +602,7 @@ class CopyNode(BaseNode):
 
     if not backend:
       backend = config.default_backend
-    #use dtype=None here; the backend dtype will be deduced from the
-    #tensor dtype.
-    backend_obj = backend_factory.get_backend(backend, dtype=None)
+    backend_obj = backend_factory.get_backend(backend)
 
     self.rank = rank
     self.dimension = dimension

--- a/tensornetwork/network_operations.py
+++ b/tensornetwork/network_operations.py
@@ -283,8 +283,9 @@ def split_node(
   backend = node.backend
   node.reorder_edges(left_edges + right_edges)
 
-  u, s, vh, trun_vals = backend.svd_decomposition(
-      node.tensor, len(left_edges), max_singular_values, max_truncation_err)
+  u, s, vh, trun_vals = backend.svd_decomposition(node.tensor, len(left_edges),
+                                                  max_singular_values,
+                                                  max_truncation_err)
   sqrt_s = backend.sqrt(s)
   u_s = u * sqrt_s
   # We have to do this since we are doing element-wise multiplication against
@@ -554,8 +555,9 @@ def split_node_full_svd(
   backend = node.backend
 
   node.reorder_edges(left_edges + right_edges)
-  u, s, vh, trun_vals = backend.svd_decomposition(
-      node.tensor, len(left_edges), max_singular_values, max_truncation_err)
+  u, s, vh, trun_vals = backend.svd_decomposition(node.tensor, len(left_edges),
+                                                  max_singular_values,
+                                                  max_truncation_err)
   left_node = Node(
       u, name=left_name, axis_names=left_axis_names, backend=backend.name)
   singular_values_node = Node(
@@ -598,7 +600,8 @@ def _reachable(nodes: Set[BaseNode]) -> Set[BaseNode]:
   return seen_nodes
 
 
-def reachable(inputs: Union[BaseNode, Iterable[BaseNode], Edge, Iterable[Edge]]) -> Set[BaseNode]:
+def reachable(inputs: Union[BaseNode, Iterable[BaseNode], Edge, Iterable[Edge]]
+             ) -> Set[BaseNode]:
   """
   Computes all nodes reachable from `node` or `edge.node1` by connected edges.
   Args:
@@ -769,9 +772,7 @@ def reduced_density(traced_out_edges: Iterable[Edge]) -> Tuple[dict, dict]:
   return node_dict, edge_dict
 
 
-def switch_backend(nodes: Iterable[BaseNode],
-                   new_backend: Text,
-                   dtype: Optional[Type[np.number]] = None) -> None:
+def switch_backend(nodes: Iterable[BaseNode], new_backend: Text) -> None:
   """Change the backend of the nodes.
 
   This will convert all node's tensors to the new backend's Tensor type.
@@ -781,7 +782,7 @@ def switch_backend(nodes: Iterable[BaseNode],
     dtype (datatype): The dtype of the backend. If None, a defautl dtype according
                        to config.py will be chosen.
   """
-  backend = backend_factory.get_backend(new_backend, dtype)
+  backend = backend_factory.get_backend(new_backend)
   for node in nodes:
     if node.backend.name != "numpy":
       raise NotImplementedError("Can only switch backends when the current "


### PR DESCRIPTION
`dtype` attribute is removed from all backends.
`BaseNode.dtype` returns `BaseNode.tensor.dtype` now
fixes #349 