### PR TITLE
compute reduced svd in `backends.numpy.decompositions.svd_decompostion`

### DIFF
--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -33,7 +33,7 @@ def svd_decomposition(
   right_dims = tensor.shape[split_axis:]
 
   tensor = np.reshape(tensor, [numpy.prod(left_dims), numpy.prod(right_dims)])
-  u, s, vh = np.linalg.svd(tensor)
+  u, s, vh = np.linalg.svd(tensor, full_matrices=False)
 
   if max_singular_values is None:
     max_singular_values = np.size(s)

--- a/tensornetwork/backends/numpy/decompositions_test.py
+++ b/tensornetwork/backends/numpy/decompositions_test.py
@@ -63,6 +63,18 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(vh.shape, (7, 10))
     self.assertAllClose(trun, np.arange(2, -1, -1))
 
+  def test_max_singular_values_larger_than_bond_dimension(self):
+    random_matrix = np.random.rand(10, 6)
+    unitary1, _, unitary2 = np.linalg.svd(random_matrix, full_matrices=False)
+    singular_values = np.array(range(6))
+    val = unitary1.dot(np.diag(singular_values).dot(unitary2.T))
+    u, s, vh, _ = decompositions.svd_decomposition(
+        np, val, 1, max_singular_values=30)
+    self.assertEqual(u.shape, (10, 6))
+    self.assertEqual(s.shape, (6,))
+    self.assertEqual(vh.shape, (6, 6))
+
+
   def test_max_truncation_error(self):
     random_matrix = np.random.rand(10, 10)
     unitary1, _, unitary2 = np.linalg.svd(random_matrix)


### PR DESCRIPTION
This is a fix for https://github.com/google/TensorNetwork/issues/419 .