### PR TITLE
Fix default axis names in _flatten_trace_edges

### DIFF
--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -1171,6 +1171,7 @@ def _flatten_trace_edges(edges: List[Edge],
   edge2 = Edge(node1=node, axis1=len(perm_front) + 1, name="TraceBack")
   node.edges = node.edges[:len(perm_front)] + [edge1, edge2]
   new_edge = connect(edge1, edge2, new_edge_name)
+  node.axis_names = [str(n) for n in range(len(node.edges))]
   # pylint: disable=expression-not-assigned
   [edge.disable() for edge in edges]  #disable edges!
   return new_edge

--- a/tensornetwork/network_components.py
+++ b/tensornetwork/network_components.py
@@ -1155,6 +1155,8 @@ def _flatten_trace_edges(edges: List[Edge],
     The new edge that represents the flattening of the given edges.
   """
   node = edges[0].node1  # We are in the trace case, so this is the only node.
+  has_nongeneric_names = (set(node.axis_names) != 
+                          {str(n) for n in range(len(node.edges))})
   backend = node.backend
   # Flatten all of the edge's axes into a a single list.
   perm_back = [min(e.axis1, e.axis2) for e in edges]
@@ -1171,7 +1173,12 @@ def _flatten_trace_edges(edges: List[Edge],
   edge2 = Edge(node1=node, axis1=len(perm_front) + 1, name="TraceBack")
   node.edges = node.edges[:len(perm_front)] + [edge1, edge2]
   new_edge = connect(edge1, edge2, new_edge_name)
-  node.axis_names = [str(n) for n in range(len(node.edges))]
+  if has_nongeneric_names:
+    node.axis_names = (node.axis_names[0:len(perm_front)] + 
+                       [node.axis_names[new_edge.axis1], 
+                        node.axis_names[new_edge.axis2]])
+  else:
+    node.axis_names = [str(n) for n in range(len(node.edges))]
   # pylint: disable=expression-not-assigned
   [edge.disable() for edge in edges]  #disable edges!
   return new_edge

--- a/tensornetwork/tests/network_test.py
+++ b/tensornetwork/tests/network_test.py
@@ -295,6 +295,30 @@ def test_flatten_trace_edges(backend):
   assert new_edge.name == "New Edge"
 
 
+def test_flatten_trace_edges_generic_names():
+  a = tn.Node(np.ones([3, 3, 2, 2, 5]))
+  a[0] ^ a[1]
+  a[2] ^ a[3]
+  tn.flatten_edges([a[0], a[2]])
+  assert(a.axis_names == ['0', '1', '2'])
+
+
+def test_flatten_trace_edges_non_generic_names():
+  a = tn.Node(np.ones([3, 3, 2, 2, 5]), axis_names=['a', 'b', 'c', 'd', 'e'])
+  a[0] ^ a[1]
+  a[2] ^ a[3]
+  tn.flatten_edges([a[0], a[2]])
+  assert(a.axis_names == ['e', 'a', 'c'])
+
+
+def test_flatten_trace_edges_non_generic_names_backwards():
+  a = tn.Node(np.ones([3, 5, 2, 3, 2]), axis_names=['a', 'b', 'c', 'd', 'e'])
+  a[0] ^ a[3]
+  a[2] ^ a[4]
+  tn.flatten_edges([a[3], a[4]])
+  assert(a.axis_names == ['b', 'a', 'c'])
+
+
 def test_flatten_edges_standard(backend):
   a = tn.Node(np.zeros((2, 3, 5)), name="A", backend=backend)
   b = tn.Node(np.zeros((2, 3, 4, 5)), name="B", backend=backend)


### PR DESCRIPTION
Re-create the axis_names for the new edge configuration after all node edges are flattened in _flatten_trace_edges