### PR TITLE
Relative svd cutoff (#422)

### DIFF
--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -64,7 +64,8 @@ class BaseBackend:
                         tensor: Tensor,
                         split_axis: int,
                         max_singular_values: Optional[int] = None,
-                        max_truncation_error: Optional[float] = None
+                        max_truncation_error: Optional[float] = None,
+                        relative: Optional[bool] = False
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     """Computes the singular value decomposition (SVD) of a tensor.
 
@@ -83,6 +84,8 @@ class BaseBackend:
     If `max_truncation_error > 0`, as many singular values will be truncated as
     possible, so that the truncation error (the norm of discarded singular
     values) is at most `max_truncation_error`.
+    If `relative` is set `True` then `max_truncation_err` is understood
+    relative to the largest singular value.
 
     If both `max_singular_values` and `max_truncation_error` are specified, the
     number of retained singular values will be
@@ -104,6 +107,7 @@ class BaseBackend:
         keep them all.
       max_truncation_error: The maximum allowed truncation error or `None` to 
         not do any truncation.
+      relative: Multiply `max_truncation_err` with the largest singular value.
 
     Returns:
       u: Left tensor factor.

--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -24,6 +24,7 @@ def svd_decomposition(
     split_axis: int,
     max_singular_values: Optional[int] = None,
     max_truncation_error: Optional[float] = None,
+    relative: Optional[bool] = False
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
   """Computes the singular value decomposition (SVD) of a tensor.
 
@@ -41,10 +42,16 @@ def svd_decomposition(
   if max_truncation_error is not None:
     # Cumulative norms of singular values in ascending order.
     trunc_errs = np.sqrt(np.cumsum(np.square(s[::-1])))
+    # If relative is true, rescale max_truncation error with the largest
+    # singular value to yield the absolute maximal truncation error.
+    if relative:
+      abs_max_truncation_error = max_truncation_error * s[0]
+    else:
+      abs_max_truncation_error = max_truncation_error
     # We must keep at least this many singular values to ensure the
-    # truncation error is <= max_truncation_error.
+    # truncation error is <= abs_max_truncation_error.
     num_sing_vals_err = np.count_nonzero(
-        (trunc_errs > max_truncation_error).astype(np.int32))
+        (trunc_errs > abs_max_truncation_error).astype(np.int32))
   else:
     num_sing_vals_err = max_singular_values
 

--- a/tensornetwork/backends/numpy/decompositions_test.py
+++ b/tensornetwork/backends/numpy/decompositions_test.py
@@ -89,5 +89,21 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertAllClose(trun, np.arange(2, -1, -1))
 
 
+  def test_max_truncation_error_relative(self):
+    absolute = np.diag([2.0, 1.0, 0.2, 0.1])
+    relative = np.diag([2.0, 1.0, 0.2, 0.1])
+    max_truncation_err = 0.2
+    _, _, _, trunc_sv_absolute = decompositions.svd_decomposition(
+        np, absolute, 1,
+        max_truncation_error=max_truncation_err,
+        relative=False)
+    _, _, _, trunc_sv_relative = decompositions.svd_decomposition(
+        np, relative, 1,
+        max_truncation_error=max_truncation_err,
+        relative=True)
+    np.testing.assert_almost_equal(trunc_sv_absolute, [0.1])
+    np.testing.assert_almost_equal(trunc_sv_relative, [0.2, 0.1])
+
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -41,11 +41,13 @@ class NumPyBackend(base_backend.BaseBackend):
                         tensor: Tensor,
                         split_axis: int,
                         max_singular_values: Optional[int] = None,
-                        max_truncation_error: Optional[float] = None
+                        max_truncation_error: Optional[float] = None,
+                        relative: Optional[bool] = False
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     return decompositions.svd_decomposition(self.np, tensor, split_axis,
                                             max_singular_values,
-                                            max_truncation_error)
+                                            max_truncation_error,
+                                            relative=relative)
 
   def qr_decomposition(
       self,

--- a/tensornetwork/backends/pytorch/decompositions.py
+++ b/tensornetwork/backends/pytorch/decompositions.py
@@ -23,7 +23,8 @@ def svd_decomposition(torch: Any,
                       tensor: Tensor,
                       split_axis: int,
                       max_singular_values: Optional[int] = None,
-                      max_truncation_error: Optional[float] = None
+                      max_truncation_error: Optional[float] = None,
+                      relative: Optional[bool] = False
                      ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
   """Computes the singular value decomposition (SVD) of a tensor.
 
@@ -42,6 +43,8 @@ def svd_decomposition(torch: Any,
   If `max_truncation_error > 0`, as many singular values will be truncated as
   possible, so that the truncation error (the norm of discarded singular
   values) is at most `max_truncation_error`.
+  If `relative` is set `True` then `max_truncation_err` is understood
+  relative to the largest singular value.
 
   If both `max_singular_values` snd `max_truncation_error` are specified, the
   number of retained singular values will be
@@ -64,6 +67,7 @@ def svd_decomposition(torch: Any,
       keep them all.
     max_truncation_error: The maximum allowed truncation error or `None` to not
       do any truncation.
+    relative: Multiply `max_truncation_err` with the largest singular value.
 
   Returns:
     u: Left tensor factor.
@@ -85,10 +89,16 @@ def svd_decomposition(torch: Any,
     # Cumulative norms of singular values in ascending order
     s_sorted, _ = torch.sort(s**2)
     trunc_errs = torch.sqrt(torch.cumsum(s_sorted, 0))
+    # If relative is true, rescale max_truncation error with the largest
+    # singular value to yield the absolute maximal truncation error.
+    if relative:
+      abs_max_truncation_error = max_truncation_error * s[0]
+    else:
+      abs_max_truncation_error = max_truncation_error
     # We must keep at least this many singular values to ensure the
-    # truncation error is <= max_truncation_error.
+    # truncation error is <= abs_max_truncation_error.
     num_sing_vals_err = torch.nonzero(
-        trunc_errs > max_truncation_error).nelement()
+        trunc_errs > abs_max_truncation_error).nelement()
   else:
     num_sing_vals_err = max_singular_values
 

--- a/tensornetwork/backends/pytorch/decompositions_test.py
+++ b/tensornetwork/backends/pytorch/decompositions_test.py
@@ -81,3 +81,19 @@ def test_max_truncation_error():
   np.testing.assert_array_almost_equal(s, np.arange(9, 2, -1), decimal=5)
   assert vh.shape == (7, 10)
   np.testing.assert_array_almost_equal(trun, np.arange(2, -1, -1))
+
+
+def test_max_truncation_error_relative():
+  absolute = np.diag([2.0, 1.0, 0.2, 0.1])
+  relative = np.diag([2.0, 1.0, 0.2, 0.1])
+  max_truncation_err = 0.2
+  _, _, _, trunc_sv_absolute = decompositions.svd_decomposition(
+      torch, torch.Tensor(absolute), 1,
+      max_truncation_error=max_truncation_err,
+      relative=False)
+  _, _, _, trunc_sv_relative = decompositions.svd_decomposition(
+      torch, torch.Tensor(relative), 1,
+      max_truncation_error=max_truncation_err,
+      relative=True)
+  np.testing.assert_almost_equal(trunc_sv_absolute, [0.1])
+  np.testing.assert_almost_equal(trunc_sv_relative, [0.2, 0.1])

--- a/tensornetwork/backends/pytorch/pytorch_backend.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend.py
@@ -49,11 +49,13 @@ class PyTorchBackend(base_backend.BaseBackend):
                         tensor: Tensor,
                         split_axis: int,
                         max_singular_values: Optional[int] = None,
-                        max_truncation_error: Optional[float] = None
+                        max_truncation_error: Optional[float] = None,
+                        relative: Optional[bool] = False
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     return decompositions.svd_decomposition(self.torch, tensor, split_axis,
                                             max_singular_values,
-                                            max_truncation_error)
+                                            max_truncation_error,
+                                            relative=relative)
 
   def qr_decomposition(
       self,

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -66,7 +66,8 @@ class ShellBackend(base_backend.BaseBackend):
                         tensor: Tensor,
                         split_axis: int,
                         max_singular_values: Optional[int] = None,
-                        max_truncation_error: Optional[float] = None
+                        max_truncation_error: Optional[float] = None,
+                        relative: Optional[bool] = False
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     if max_truncation_error is not None:
       raise NotImplementedError("SVD with truncation shape cannot be "

--- a/tensornetwork/backends/tensorflow/decompositions_test.py
+++ b/tensornetwork/backends/tensorflow/decompositions_test.py
@@ -101,6 +101,21 @@ class DecompositionsTest(tf.test.TestCase):
     self.assertEqual(vh.shape, (7, 10))
     self.assertAllClose(trun, np.arange(2, -1, -1))
 
+  def test_max_truncation_error_relative(self):
+    absolute = np.diag([2.0, 1.0, 0.2, 0.1])
+    relative = np.diag([2.0, 1.0, 0.2, 0.1])
+    max_truncation_err = 0.2
+    _, _, _, trunc_sv_absolute = decompositions.svd_decomposition(
+        tf, absolute, 1,
+        max_truncation_error=max_truncation_err,
+        relative=False)
+    _, _, _, trunc_sv_relative = decompositions.svd_decomposition(
+        tf, relative, 1,
+        max_truncation_error=max_truncation_err,
+        relative=True)
+    np.testing.assert_almost_equal(trunc_sv_absolute, [0.1])
+    np.testing.assert_almost_equal(trunc_sv_relative, [0.2, 0.1])
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -50,11 +50,13 @@ class TensorFlowBackend(base_backend.BaseBackend):
                         tensor: Tensor,
                         split_axis: int,
                         max_singular_values: Optional[int] = None,
-                        max_truncation_error: Optional[float] = None
+                        max_truncation_error: Optional[float] = None,
+                        relative: Optional[bool] = False
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     return decompositions.svd_decomposition(self.tf, tensor, split_axis,
                                             max_singular_values,
-                                            max_truncation_error)
+                                            max_truncation_error,
+                                            relative=relative)
 
   def qr_decomposition(self, tensor: Tensor,
                        split_axis: int) -> Tuple[Tensor, Tensor]:

--- a/tensornetwork/network_operations.py
+++ b/tensornetwork/network_operations.py
@@ -187,6 +187,7 @@ def split_node(
     right_edges: List[Edge],
     max_singular_values: Optional[int] = None,
     max_truncation_err: Optional[float] = None,
+    relative: Optional[bool] = False,
     left_name: Optional[Text] = None,
     right_name: Optional[Text] = None,
     edge_name: Optional[Text] = None,
@@ -207,6 +208,8 @@ def split_node(
   values. If only `max_truncation_err` is set, as many singular values will
   be truncated as possible while maintaining:
   `norm(truncated_singular_values) <= max_truncation_err`.
+  If `relative` is set `True` then `max_truncation_err` is understood
+  relative to the largest singular value.
 
   If only `max_singular_values` is set, the number of singular values kept
   will be `min(max_singular_values, number_of_singular_values)`, so that
@@ -222,6 +225,7 @@ def split_node(
     right_edges: The edges you want connected to the new right node.
     max_singular_values: The maximum number of singular values to keep.
     max_truncation_err: The maximum allowed truncation error.
+    relative: Multiply `max_truncation_err` with the largest singular value.
     left_name: The name of the new left node. If `None`, a name will be 
       generated automatically.
     right_name: The name of the new right node. If `None`, a name will be 
@@ -267,7 +271,8 @@ def split_node(
 
   u, s, vh, trun_vals = backend.svd_decomposition(node.tensor, len(left_edges),
                                                   max_singular_values,
-                                                  max_truncation_err)
+                                                  max_truncation_err,
+                                                  relative=relative)
   sqrt_s = backend.sqrt(s)
   u_s = u * sqrt_s
   # We have to do this since we are doing element-wise multiplication against
@@ -447,6 +452,7 @@ def split_node_full_svd(
     right_edges: List[Edge],
     max_singular_values: Optional[int] = None,
     max_truncation_err: Optional[float] = None,
+    relative: Optional[bool] = False,
     left_name: Optional[Text] = None,
     middle_name: Optional[Text] = None,
     right_name: Optional[Text] = None,
@@ -470,6 +476,8 @@ def split_node_full_svd(
   values. If only `max_truncation_err` is set, as many singular values will
   be truncated as possible while maintaining:
   `norm(truncated_singular_values) <= max_truncation_err`.
+  If `relative` is set `True` then `max_truncation_err` is understood
+  relative to the largest singular value.
 
   If only `max_singular_values` is set, the number of singular values kept
   will be `min(max_singular_values, number_of_singular_values)`, so that
@@ -485,6 +493,7 @@ def split_node_full_svd(
     right_edges: The edges you want connected to the new right node.
     max_singular_values: The maximum number of singular values to keep.
     max_truncation_err: The maximum allowed truncation error.
+    relative: Multiply `max_truncation_err` with the largest singular value.
     left_name: The name of the new left node. If None, a name will be 
       generated automatically.
     middle_name: The name of the new center node. If None, a name will be 
@@ -539,7 +548,8 @@ def split_node_full_svd(
   node.reorder_edges(left_edges + right_edges)
   u, s, vh, trun_vals = backend.svd_decomposition(node.tensor, len(left_edges),
                                                   max_singular_values,
-                                                  max_truncation_err)
+                                                  max_truncation_err,
+                                                  relative=relative)
   left_node = Node(
       u, name=left_name, axis_names=left_axis_names, backend=backend)
   singular_values_node = Node(

--- a/tensornetwork/tests/network_operations_test.py
+++ b/tensornetwork/tests/network_operations_test.py
@@ -38,6 +38,48 @@ def test_split_node_full_svd_names(backend):
   assert right.edges[0].name == 'right_edge'
 
 
+def test_split_node_relative_tolerance(backend):
+  absolute = tn.Node(np.diag([2.0, 1.0, 0.2, 0.1]), backend=backend)
+  relative = tn.Node(np.diag([2.0, 1.0, 0.2, 0.1]), backend=backend) 
+  max_truncation_err = 0.2
+
+  _, _, trunc_sv_absolute, = tn.split_node(
+      node=absolute,
+      left_edges=[absolute[0]],
+      right_edges=[absolute[1]],
+      max_truncation_err=max_truncation_err,
+      relative=False)
+  _, _, trunc_sv_relative, = tn.split_node(
+      node=relative,
+      left_edges=[relative[0]],
+      right_edges=[relative[1]],
+      max_truncation_err=max_truncation_err,
+      relative=True)
+  np.testing.assert_almost_equal(trunc_sv_absolute, [0.1])
+  np.testing.assert_almost_equal(trunc_sv_relative, [0.2, 0.1])
+
+
+def test_split_node_full_svd_relative_tolerance(backend):
+  absolute = tn.Node(np.diag([2.0, 1.0, 0.2, 0.1]), backend=backend)
+  relative = tn.Node(np.diag([2.0, 1.0, 0.2, 0.1]), backend=backend) 
+  max_truncation_err = 0.2
+
+  _, _, _, trunc_sv_absolute, = tn.split_node_full_svd(
+      node=absolute,
+      left_edges=[absolute[0]],
+      right_edges=[absolute[1]],
+      max_truncation_err=max_truncation_err,
+      relative=False)
+  _, _, _, trunc_sv_relative, = tn.split_node_full_svd(
+      node=relative,
+      left_edges=[relative[0]],
+      right_edges=[relative[1]],
+      max_truncation_err=max_truncation_err,
+      relative=True)
+  np.testing.assert_almost_equal(trunc_sv_absolute, [0.1])
+  np.testing.assert_almost_equal(trunc_sv_relative, [0.2, 0.1])
+
+
 def test_split_node_rq_names(backend):
   a = tn.Node(np.zeros((2, 3, 4, 5, 6)), backend=backend)
   left_edges = []


### PR DESCRIPTION
Adds a `relative: Optional[bool] = False` parameter in `split_node()` and `split_node_full_svd()` to make `max_truncation_err` relative to the largest singular value (#422 ).

* Add relative svd_cutoff in network_operations
* Add relative svd_cutoff in base_backend
* Add relative svd_cutoff in numpy backend
* Add relative svd_cutoff in pytorch backend
* Add relative svd_cutoff in tensorflow backend
* Add tests for relative svd_cutoff in network_operations
* Add tests for relative svd_cutoff in numpy backend
* Add tests for relative svd_cutoff in pytorch backend
* Add tests for relative svd_cutoff in tensorflow backend
