### PR TITLE
Fix compute sparse lookup

### DIFF
--- a/tensornetwork/block_sparse/utils.py
+++ b/tensornetwork/block_sparse/utils.py
@@ -104,7 +104,7 @@ def compute_sparse_lookup(
 
   fused_charges = fuse_charges(charges, flows)
   unique_charges, inverse = fused_charges.unique(return_inverse=True)
-  c, label_to_unique, _ = unique_charges.intersect(
+  _, label_to_unique, _ = unique_charges.intersect(
       target_charges, return_indices=True)
   tmp = np.full(len(unique_charges), fill_value=-1, dtype=np.int16)
   tmp[label_to_unique] = label_to_unique

--- a/tensornetwork/block_sparse/utils.py
+++ b/tensornetwork/block_sparse/utils.py
@@ -99,20 +99,19 @@ def compute_sparse_lookup(
       `len(unique_charges)`. The position of values `n` in `lookup` are positions
        with charge values `unique_charges[n]`.
     unique_charges: The unique charges of fusion of `charges`
-    label_to_unique: The  integer labels of the unique charges.
+    label_to_unique: The integer labels of the unique charges.
   """
 
   fused_charges = fuse_charges(charges, flows)
   unique_charges, inverse = fused_charges.unique(return_inverse=True)
-  _, label_to_unique, _ = unique_charges.intersect(
+  c, label_to_unique, _ = unique_charges.intersect(
       target_charges, return_indices=True)
-
   tmp = np.full(len(unique_charges), fill_value=-1, dtype=np.int16)
   tmp[label_to_unique] = label_to_unique
   lookup = tmp[inverse]
   lookup = lookup[lookup >= 0]
 
-  return lookup, unique_charges, label_to_unique
+  return lookup, unique_charges, np.sort(label_to_unique)
 
 
 def _get_strides(dims: Union[List[int], np.ndarray]) -> np.ndarray:

--- a/tensornetwork/block_sparse/utils_test.py
+++ b/tensornetwork/block_sparse/utils_test.py
@@ -71,6 +71,23 @@ def test_compute_sparse_lookup():
   np.testing.assert_allclose(labels, expected_labels_to_unique)
 
 
+@pytest.mark.parametrize('flow', [True, False])
+def test_compute_sparse_lookup_non_ordered(flow):
+  np_flow = np.int(-(np.int(flow) - 0.5) * 2)
+  charge_labels = np.array([0, 0, 1, 5, 5, 0, 2, 3, 2, 3, 4, 0, 3, 3, 1, 5])
+  unique_charges = np.array([-1, 0, 1, -5, 7, 2])
+  np_targets = np.array([-1, 0, 2])
+  charges = [U1Charge(unique_charges, charge_labels=charge_labels)]
+  inds = np.nonzero(
+      np.isin((np_flow * unique_charges)[charge_labels], np_targets))[0]
+  targets = U1Charge(np_targets)
+  lookup, unique, labels = compute_sparse_lookup(charges, [flow], targets)
+  np.testing.assert_allclose(labels, np.sort(labels))
+  np.testing.assert_allclose(
+      np.squeeze(unique.charges[:, lookup]),
+      (np_flow * unique_charges)[charge_labels][inds])
+
+
 def test_find_best_partition():
   with pytest.raises(ValueError):
     _find_best_partition([5])


### PR DESCRIPTION
there was a `sort` missing, which caused a bug in block_sparse.diag(). The error occured for non-ordered charges. This PR fixes the issue