### PR TITLE
Backend broadcast 2

### DIFF
--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -475,7 +475,9 @@ class BaseBackend:
   def broadcast_right_multiplication(self, tensor1: Tensor, tensor2: Tensor):
     """
     Perform broadcasting for multiplication of `tensor2` onto `tensor1`, i.e.
-    `tensor1` * tensor2`.
+    `tensor1` * tensor2`, where `tensor1` is an arbitrary tensor and `tensor2` is a
+    one-dimensional tensor. The broadcasting is applied to the last index of 
+    `tensor1`.
     Args:
       tensor1: A tensor.
       tensor2: A tensor.
@@ -484,4 +486,20 @@ class BaseBackend:
     """
     raise NotImplementedError(
         "Backend '{}' has not implemented `broadcast_right_multiplication`."
+        .format(self.name))
+
+  def broadcast_left_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    """
+    Perform broadcasting for multiplication of `tensor1` onto `tensor2`, i.e.
+    `tensor1` * tensor2`, where `tensor2` is an arbitrary tensor and `tensor1` is a
+    one-dimensional tensor. The broadcasting is applied to the first index of 
+    `tensor2`.
+    Args:
+      tensor1: A tensor.
+      tensor2: A tensor.
+    Returns:
+      Tensor: The result of multiplying `tensor1` onto `tensor2`.
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented `broadcast_left_multiplication`."
         .format(self.name))

--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -354,16 +354,16 @@ class BaseBackend:
     raise NotImplementedError("Backend '{}' has not implemented eigs.".format(
         self.name))
 
-  def eigsh_lanczos(self,
-                    A: Callable,
-                    initial_state: Optional[Tensor] = None,
-                    num_krylov_vecs: Optional[int] = 200,
-                    numeig: Optional[int] = 1,
-                    tol: Optional[float] = 1E-8,
-                    delta: Optional[float] = 1E-8,
-                    ndiag: Optional[int] = 20,
-                    reorthogonalize: Optional[bool] = False
-                   ) -> Tuple[List, List]:
+  def eigsh_lanczos(
+      self,
+      A: Callable,
+      initial_state: Optional[Tensor] = None,
+      num_krylov_vecs: Optional[int] = 200,
+      numeig: Optional[int] = 1,
+      tol: Optional[float] = 1E-8,
+      delta: Optional[float] = 1E-8,
+      ndiag: Optional[int] = 20,
+      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
     """
     Lanczos method for finding the lowest eigenvector-eigenvalue pairs
     of `A`. 
@@ -444,8 +444,8 @@ class BaseBackend:
       Returns:
         Tensor
     """
-    raise NotImplementedError(
-        "Backend '{}' has not implemented divide.".format(self.name))
+    raise NotImplementedError("Backend '{}' has not implemented divide.".format(
+        self.name))
 
   def index_update(self, tensor: Tensor, mask: Tensor,
                    assignee: Tensor) -> Tensor:
@@ -471,3 +471,17 @@ class BaseBackend:
     """
     raise NotImplementedError("Backend '{}' has not implemented `inv`.".format(
         self.name))
+
+  def broadcast_right_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    """
+    Perform broadcasting for multiplication of `tensor2` onto `tensor1`, i.e.
+    `tensor1` * tensor2`.
+    Args:
+      tensor1: A tensor.
+      tensor2: A tensor.
+    Returns:
+      Tensor: The result of multiplying `tensor1` onto `tensor2`.
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented `broadcast_right_multiplication`."
+        .format(self.name))

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -241,8 +241,8 @@ def test_random_uniform_boundaries(dtype):
   backend = jax_backend.JaxBackend()
   a = backend.random_uniform((4, 4), seed=10, dtype=dtype)
   b = backend.random_uniform((4, 4), (lb, ub), seed=10, dtype=dtype)
-  assert((a >= 0).all() and (a <= 1).all() and
-         (b >= lb).all() and (b <= ub).all())
+  assert ((a >= 0).all() and (a <= 1).all() and (b >= lb).all() and
+          (b <= ub).all())
 
 
 def test_random_uniform_behavior():
@@ -296,3 +296,20 @@ def test_index_update(dtype):
   np_tensor = np.array(tensor)
   np_tensor[np_tensor > 0.1] = 0.0
   np.testing.assert_allclose(out, np_tensor)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+def test_broadcast_right_multiplication(dtype):
+  backend = jax_backend.JaxBackend()
+  tensor1 = backend.randn((2, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3,), dtype=dtype, seed=10)
+  out = backend.broadcast_right_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out, np.array(tensor1) * np.array(tensor2))
+
+
+def test_broadcast_right_multiplication_raises():
+  backend = jax_backend.JaxBackend()
+  tensor1 = backend.randn((2, 3))
+  tensor2 = backend.randn((3, 3))
+  with pytest.raises(ValueError):
+    backend.broadcast_right_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -313,3 +313,21 @@ def test_broadcast_right_multiplication_raises():
   tensor2 = backend.randn((3, 3))
   with pytest.raises(ValueError):
     backend.broadcast_right_multiplication(tensor1, tensor2)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+def test_broadcast_left_multiplication(dtype):
+  backend = jax_backend.JaxBackend()
+  tensor1 = backend.randn((3,), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3, 4, 2), dtype=dtype, seed=10)
+  out = backend.broadcast_left_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out, np.reshape(tensor1, (3, 1, 1)) * tensor2)
+
+
+def test_broadcast_left_multiplication_raises():
+  dtype = np.float64
+  backend = jax_backend.JaxBackend()
+  tensor1 = backend.randn((3, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    backend.broadcast_left_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -44,10 +44,13 @@ class NumPyBackend(base_backend.BaseBackend):
                         max_truncation_error: Optional[float] = None,
                         relative: Optional[bool] = False
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
-    return decompositions.svd_decomposition(self.np, tensor, split_axis,
-                                            max_singular_values,
-                                            max_truncation_error,
-                                            relative=relative)
+    return decompositions.svd_decomposition(
+        self.np,
+        tensor,
+        split_axis,
+        max_singular_values,
+        max_truncation_error,
+        relative=relative)
 
   def qr_decomposition(
       self,
@@ -145,12 +148,12 @@ class NumPyBackend(base_backend.BaseBackend):
     dtype = dtype if dtype is not None else self.np.float64
     if ((self.np.dtype(dtype) is self.np.dtype(self.np.complex128)) or
         (self.np.dtype(dtype) is self.np.dtype(self.np.complex64))):
-      return self.np.random.uniform(boundaries[0], boundaries[1], shape).astype(
-          dtype) + 1j * self.np.random.uniform(boundaries[0],
-                                               boundaries[1],
-                                               shape).astype(dtype)
-    return self.np.random.uniform(boundaries[0],
-                                  boundaries[1], shape).astype(dtype)
+      return self.np.random.uniform(
+          boundaries[0], boundaries[1],
+          shape).astype(dtype) + 1j * self.np.random.uniform(
+              boundaries[0], boundaries[1], shape).astype(dtype)
+    return self.np.random.uniform(boundaries[0], boundaries[1],
+                                  shape).astype(dtype)
 
   def conj(self, tensor: Tensor) -> Tensor:
     return self.np.conj(tensor)
@@ -244,16 +247,16 @@ class NumPyBackend(base_backend.BaseBackend):
       U = U.astype(dtype)
     return list(eta), [U[:, n] for n in range(numeig)]
 
-  def eigsh_lanczos(self,
-                    A: Callable,
-                    initial_state: Optional[Tensor] = None,
-                    num_krylov_vecs: Optional[int] = 200,
-                    numeig: Optional[int] = 1,
-                    tol: Optional[float] = 1E-8,
-                    delta: Optional[float] = 1E-8,
-                    ndiag: Optional[int] = 20,
-                    reorthogonalize: Optional[bool] = False
-                   ) -> Tuple[List, List]:
+  def eigsh_lanczos(
+      self,
+      A: Callable,
+      initial_state: Optional[Tensor] = None,
+      num_krylov_vecs: Optional[int] = 200,
+      numeig: Optional[int] = 1,
+      tol: Optional[float] = 1E-8,
+      delta: Optional[float] = 1E-8,
+      ndiag: Optional[int] = 20,
+      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
     """
     Lanczos method for finding the lowest eigenvector-eigenvalue pairs
     of a linear operator `A`. If no `initial_state` is provided
@@ -396,3 +399,9 @@ class NumPyBackend(base_backend.BaseBackend):
       raise ValueError("input to numpy backend method `inv` has shape {}."
                        " Only matrices are supported.".format(matrix.shape))
     return self.np.linalg.inv(matrix)
+
+  def broadcast_right_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(tensor2.shape) != 1:
+      raise ValueError("only order-1 tensors are allowed for `tensor2`,"
+                       " found `tensor2.shape = {}`".format(tensor2.shape))
+    return tensor1 * tensor2

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -405,3 +405,12 @@ class NumPyBackend(base_backend.BaseBackend):
       raise ValueError("only order-1 tensors are allowed for `tensor2`,"
                        " found `tensor2.shape = {}`".format(tensor2.shape))
     return tensor1 * tensor2
+
+  def broadcast_left_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(tensor1.shape) != 1:
+      raise ValueError("only order-1 tensors are allowed for `tensor1`,"
+                       " found `tensor1.shape = {}`".format(tensor1.shape))
+
+    t1_broadcast_shape = self.shape_concat(
+        [self.shape_tensor(tensor1), [1] * (len(tensor2.shape) - 1)], axis=-1)
+    return tensor2 * self.reshape(tensor1, t1_broadcast_shape)

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -629,3 +629,21 @@ def test_broadcast_right_multiplication_raises():
   tensor2 = backend.randn((3, 3), dtype=dtype, seed=10)
   with pytest.raises(ValueError):
     backend.broadcast_right_multiplication(tensor1, tensor2)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+def test_broadcast_left_multiplication(dtype):
+  backend = numpy_backend.NumPyBackend()
+  tensor1 = backend.randn((3,), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3, 4, 2), dtype=dtype, seed=10)
+  out = backend.broadcast_left_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out, np.reshape(tensor1, (3, 1, 1)) * tensor2)
+
+
+def test_broadcast_left_multiplication_raises():
+  dtype = np.float64
+  backend = numpy_backend.NumPyBackend()
+  tensor1 = backend.randn((3, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    backend.broadcast_left_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -239,8 +239,8 @@ def test_random_uniform_boundaries(dtype):
   backend = numpy_backend.NumPyBackend()
   a = backend.random_uniform((4, 4), seed=10, dtype=dtype)
   b = backend.random_uniform((4, 4), (lb, ub), seed=10, dtype=dtype)
-  assert((a >= 0).all() and (a <= 1).all() and
-         (b >= lb).all() and (b <= ub).all())
+  assert ((a >= 0).all() and (a <= 1).all() and (b >= lb).all() and
+          (b <= ub).all())
 
 
 def test_random_uniform_behavior():
@@ -329,8 +329,8 @@ def test_eigsh_lanczos_reorthogonalize(dtype):
       return np.dot(H, x)
 
   mv = LinearOperator(shape=((D,), (D,)), dtype=dtype)
-  eta1, U1 = backend.eigsh_lanczos(mv, reorthogonalize=True, ndiag=1,
-                                   tol=10**(-12), delta=10**(-12))
+  eta1, U1 = backend.eigsh_lanczos(
+      mv, reorthogonalize=True, ndiag=1, tol=10**(-12), delta=10**(-12))
   eta2, U2 = np.linalg.eigh(H)
   v2 = U2[:, 0]
   v2 = v2 / sum(v2)
@@ -353,7 +353,7 @@ def test_eigsh_lanczos_raises():
 def test_eigsh_lanczos_raises_error_for_incompatible_shapes():
   backend = numpy_backend.NumPyBackend()
   A = backend.randn((4, 4), dtype=np.float64)
-  init = backend.randn((3, ), dtype=np.float64)
+  init = backend.randn((3,), dtype=np.float64)
   with pytest.raises(ValueError):
     backend.eigsh_lanczos(A, initial_state=init)
 
@@ -371,7 +371,7 @@ def test_eigsh_lanczos_raises_error_for_untyped_A():
 def test_eigsh_lanczos_raises_error_for_bad_initial_state():
   backend = numpy_backend.NumPyBackend()
   D = 16
-  init = [1]*D
+  init = [1] * D
   M = backend.randn((D, D), dtype=np.float64)
 
   def mv(x):
@@ -383,9 +383,10 @@ def test_eigsh_lanczos_raises_error_for_bad_initial_state():
 
 @pytest.mark.parametrize("a, b, expected", [
     pytest.param(1, 1, 2),
-    pytest.param(1., np.ones((1, 2, 3)), 2*np.ones((1, 2, 3))),
-    pytest.param(2.*np.ones(()), 1., 3.*np.ones((1, 2, 3))),
-    pytest.param(2.*np.ones(()), 1.*np.ones((1, 2, 3)), 3.*np.ones((1, 2, 3))),
+    pytest.param(1., np.ones((1, 2, 3)), 2 * np.ones((1, 2, 3))),
+    pytest.param(2. * np.ones(()), 1., 3. * np.ones((1, 2, 3))),
+    pytest.param(2. * np.ones(()), 1. * np.ones((1, 2, 3)), 3. * np.ones(
+        (1, 2, 3))),
 ])
 def test_addition(a, b, expected):
   backend = numpy_backend.NumPyBackend()
@@ -399,7 +400,7 @@ def test_addition(a, b, expected):
 
 @pytest.mark.parametrize("a, b, expected", [
     pytest.param(1, 1, 0),
-    pytest.param(2., 1.*np.ones((1, 2, 3)), 1.*np.ones((1, 2, 3))),
+    pytest.param(2., 1. * np.ones((1, 2, 3)), 1. * np.ones((1, 2, 3))),
     pytest.param(np.ones((1, 2, 3)), 1., np.zeros((1, 2, 3))),
     pytest.param(np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.zeros((1, 2, 3))),
 ])
@@ -415,7 +416,7 @@ def test_subtraction(a, b, expected):
 
 @pytest.mark.parametrize("a, b, expected", [
     pytest.param(1, 1, 1),
-    pytest.param(2., 1.*np.ones((1, 2, 3)), 2.*np.ones((1, 2, 3))),
+    pytest.param(2., 1. * np.ones((1, 2, 3)), 2. * np.ones((1, 2, 3))),
     pytest.param(np.ones((1, 2, 3)), 1., np.ones((1, 2, 3))),
     pytest.param(np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 3))),
 ])
@@ -431,9 +432,10 @@ def test_multiply(a, b, expected):
 
 @pytest.mark.parametrize("a, b, expected", [
     pytest.param(2., 2., 1.),
-    pytest.param(2., 0.5*np.ones((1, 2, 3)), 4.*np.ones((1, 2, 3))),
-    pytest.param(np.ones(()), 2., 0.5*np.ones((1, 2, 3))),
-    pytest.param(np.ones(()), 2.*np.ones((1, 2, 3)), 0.5*np.ones((1, 2, 3))),
+    pytest.param(2., 0.5 * np.ones((1, 2, 3)), 4. * np.ones((1, 2, 3))),
+    pytest.param(np.ones(()), 2., 0.5 * np.ones((1, 2, 3))),
+    pytest.param(
+        np.ones(()), 2. * np.ones((1, 2, 3)), 0.5 * np.ones((1, 2, 3))),
 ])
 def test_divide(a, b, expected):
   backend = numpy_backend.NumPyBackend()
@@ -531,7 +533,7 @@ def test_eigs_raises_error_for_unsupported_which(which):
 def test_eigs_raises_error_for_incompatible_shapes():
   backend = numpy_backend.NumPyBackend()
   A = backend.randn((4, 4), dtype=np.float64)
-  init = backend.randn((3, ), dtype=np.float64)
+  init = backend.randn((3,), dtype=np.float64)
   with pytest.raises(ValueError):
     backend.eigs(A, initial_state=init)
 
@@ -559,7 +561,7 @@ def test_eigs_raises_error_for_untyped_A():
 def test_eigs_raises_error_for_bad_initial_state():
   backend = numpy_backend.NumPyBackend()
   D = 16
-  init = [1]*D
+  init = [1] * D
   M = backend.randn((D, D), dtype=np.float64)
 
   def mv(x):
@@ -609,3 +611,21 @@ def test_matrix_inv_raises(dtype):
   matrix = backend.randn((4, 4, 4), dtype=dtype, seed=10)
   with pytest.raises(ValueError):
     backend.inv(matrix)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+def test_broadcast_right_multiplication(dtype):
+  backend = numpy_backend.NumPyBackend()
+  tensor1 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3,), dtype=dtype, seed=10)
+  out = backend.broadcast_right_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out, tensor1 * tensor2)
+
+
+def test_broadcast_right_multiplication_raises():
+  dtype = np.float64
+  backend = numpy_backend.NumPyBackend()
+  tensor1 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3, 3), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    backend.broadcast_right_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/pytorch/pytorch_backend.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend.py
@@ -313,3 +313,12 @@ class PyTorchBackend(base_backend.BaseBackend):
           .format(tensor2.shape))
 
     return tensor1 * tensor2
+
+  def broadcast_left_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(tensor1.shape) != 1:
+      raise ValueError("only order-1 tensors are allowed for `tensor1`,"
+                       " found `tensor1.shape = {}`".format(tensor1.shape))
+
+    t1_broadcast_shape = self.shape_concat(
+        [self.shape_tensor(tensor1), [1] * (len(tensor2.shape) - 1)], axis=-1)
+    return tensor2 * self.reshape(tensor1, t1_broadcast_shape)

--- a/tensornetwork/backends/pytorch/pytorch_backend.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend.py
@@ -52,10 +52,13 @@ class PyTorchBackend(base_backend.BaseBackend):
                         max_truncation_error: Optional[float] = None,
                         relative: Optional[bool] = False
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
-    return decompositions.svd_decomposition(self.torch, tensor, split_axis,
-                                            max_singular_values,
-                                            max_truncation_error,
-                                            relative=relative)
+    return decompositions.svd_decomposition(
+        self.torch,
+        tensor,
+        split_axis,
+        max_singular_values,
+        max_truncation_error,
+        relative=relative)
 
   def qr_decomposition(
       self,
@@ -158,16 +161,16 @@ class PyTorchBackend(base_backend.BaseBackend):
     raise NotImplementedError("Backend '{}' has not implemented eigs.".format(
         self.name))
 
-  def eigsh_lanczos(self,
-                    A: Callable,
-                    initial_state: Optional[Tensor] = None,
-                    num_krylov_vecs: Optional[int] = 200,
-                    numeig: Optional[int] = 1,
-                    tol: Optional[float] = 1E-8,
-                    delta: Optional[float] = 1E-8,
-                    ndiag: Optional[int] = 20,
-                    reorthogonalize: Optional[bool] = False
-                   ) -> Tuple[List, List]:
+  def eigsh_lanczos(
+      self,
+      A: Callable,
+      initial_state: Optional[Tensor] = None,
+      num_krylov_vecs: Optional[int] = 200,
+      numeig: Optional[int] = 1,
+      tol: Optional[float] = 1E-8,
+      delta: Optional[float] = 1E-8,
+      ndiag: Optional[int] = 20,
+      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
     """
     Lanczos method for finding the lowest eigenvector-eigenvalue pairs
     of a `LinearOperator` `A`.
@@ -302,3 +305,11 @@ class PyTorchBackend(base_backend.BaseBackend):
           "input to pytorch backend method `inv` has shape {}. Only matrices are supported."
           .format(matrix.shape))
     return matrix.inverse()
+
+  def broadcast_right_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(tensor2.shape) != 1:
+      raise ValueError(
+          "only order-1 tensors are allowed for `tensor2`, found `tensor2.shape = {}`"
+          .format(tensor2.shape))
+
+    return tensor1 * tensor2

--- a/tensornetwork/backends/pytorch/pytorch_backend_test.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend_test.py
@@ -461,3 +461,21 @@ def test_broadcast_right_multiplication_raises():
   tensor2 = backend.randn((3, 3), dtype=dtype, seed=10)
   with pytest.raises(ValueError):
     backend.broadcast_right_multiplication(tensor1, tensor2)
+
+
+def test_broadcast_left_multiplication():
+  dtype = torch.float64
+  backend = pytorch_backend.PyTorchBackend()
+  tensor1 = backend.randn((3,), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3, 4, 2), dtype=dtype, seed=10)
+  out = backend.broadcast_left_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out, np.reshape(tensor1, (3, 1, 1)) * tensor2)
+
+
+def test_broadcast_left_multiplication_raises():
+  dtype = torch.float64
+  backend = pytorch_backend.PyTorchBackend()
+  tensor1 = backend.randn((3, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    backend.broadcast_left_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/pytorch/pytorch_backend_test.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend_test.py
@@ -214,8 +214,8 @@ def test_random_uniform_boundaries(dtype):
   backend = pytorch_backend.PyTorchBackend()
   a = backend.random_uniform((4, 4), seed=10, dtype=dtype)
   b = backend.random_uniform((4, 4), (lb, ub), seed=10, dtype=dtype)
-  assert(torch.ge(a, 0).byte().all() and torch.le(a, 1).byte().all() and
-         torch.ge(b, lb).byte().all() and torch.le(b, ub).byte().all())
+  assert (torch.ge(a, 0).byte().all() and torch.le(a, 1).byte().all() and
+          torch.ge(b, lb).byte().all() and torch.le(b, ub).byte().all())
 
 
 def test_random_uniform_behavior():
@@ -301,8 +301,8 @@ def test_eigsh_lanczos_2():
       return H.mv(x)
 
   mv = LinearOperator(shape=((D,), (D,)), dtype=dtype)
-  eta1, U1 = backend.eigsh_lanczos(mv, reorthogonalize=True, ndiag=1,
-                                   tol=10**(-12), delta=10**(-12))
+  eta1, U1 = backend.eigsh_lanczos(
+      mv, reorthogonalize=True, ndiag=1, tol=10**(-12), delta=10**(-12))
   eta2, U2 = H.symeig(eigenvectors=True)
   v2 = U2[:, 0]
   v2 = v2 / sum(v2)
@@ -324,7 +324,8 @@ def test_eigsh_lanczos_raises():
 
 @pytest.mark.parametrize("a, b, expected", [
     pytest.param(1, 1, 2),
-    pytest.param(np.ones((1, 2, 3)), np.ones((1, 2, 3)), 2.*np.ones((1, 2, 3))),
+    pytest.param(
+        np.ones((1, 2, 3)), np.ones((1, 2, 3)), 2. * np.ones((1, 2, 3))),
 ])
 def test_addition(a, b, expected):
   backend = pytorch_backend.PyTorchBackend()
@@ -366,7 +367,8 @@ def test_multiply(a, b, expected):
 
 @pytest.mark.parametrize("a, b, expected", [
     pytest.param(2., 2., 1.),
-    pytest.param(np.ones(()), 2.*np.ones((1, 2, 3)), 0.5*np.ones((1, 2, 3))),
+    pytest.param(
+        np.ones(()), 2. * np.ones((1, 2, 3)), 0.5 * np.ones((1, 2, 3))),
 ])
 def test_divide(a, b, expected):
   backend = pytorch_backend.PyTorchBackend()
@@ -429,7 +431,7 @@ def test_eigs_not_implemented():
 def test_eigsh_lanczos_raises_error_for_incompatible_shapes():
   backend = pytorch_backend.PyTorchBackend()
   A = backend.randn((4, 4), dtype=torch.float64)
-  init = backend.randn((3, ), dtype=torch.float64)
+  init = backend.randn((3,), dtype=torch.float64)
   with pytest.raises(ValueError):
     backend.eigsh_lanczos(A, initial_state=init)
 
@@ -442,3 +444,20 @@ def test_eigsh_lanczos_raises_error_for_untyped_A():
             "Please provide a valid `initial_state` with a `dtype` attribute"
   with pytest.raises(AttributeError, match=err_msg):
     backend.eigsh_lanczos(A)
+
+
+def test_broadcast_right_multiplication():
+  backend = pytorch_backend.PyTorchBackend()
+  tensor1 = backend.randn((2, 4, 3), dtype=torch.float64, seed=10)
+  tensor2 = backend.randn((3,), dtype=torch.float64, seed=10)
+  out = backend.broadcast_right_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out, tensor1 * tensor2)
+
+
+def test_broadcast_right_multiplication_raises():
+  dtype = torch.float64
+  backend = pytorch_backend.PyTorchBackend()
+  tensor1 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3, 3), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    backend.broadcast_right_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -242,26 +242,28 @@ class ShellBackend(base_backend.BaseBackend):
       if not hasattr(A, 'shape'):
         raise AttributeError("`A` has no  attribute `shape`. Cannot initialize "
                              "lanczos. Please provide a valid `initial_state`")
-      return [ShellTensor(tuple()) for _ in range(numeig)
-             ], [ShellTensor((A.shape[0],)) for _ in range(numeig)]
+      return [ShellTensor(tuple()) for _ in range(numeig)], [
+          ShellTensor((A.shape[0],)) for _ in range(numeig)
+      ]
 
     if initial_state is not None:
-      return [ShellTensor(tuple()) for _ in range(numeig)
-             ], [ShellTensor(initial_state.shape) for _ in range(numeig)]
+      return [ShellTensor(tuple()) for _ in range(numeig)], [
+          ShellTensor(initial_state.shape) for _ in range(numeig)
+      ]
 
     raise ValueError(
         '`A` has no attribut shape and no `initial_state` is given.')
 
-  def eigsh_lanczos(self,
-                    A: Callable,
-                    initial_state: Optional[Tensor] = None,
-                    num_krylov_vecs: Optional[int] = 200,
-                    numeig: Optional[int] = 1,
-                    tol: Optional[float] = 1E-8,
-                    delta: Optional[float] = 1E-8,
-                    ndiag: Optional[int] = 20,
-                    reorthogonalize: Optional[bool] = False
-                   ) -> Tuple[List, List]:
+  def eigsh_lanczos(
+      self,
+      A: Callable,
+      initial_state: Optional[Tensor] = None,
+      num_krylov_vecs: Optional[int] = 200,
+      numeig: Optional[int] = 1,
+      tol: Optional[float] = 1E-8,
+      delta: Optional[float] = 1E-8,
+      ndiag: Optional[int] = 20,
+      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
 
     if num_krylov_vecs < numeig:
       raise ValueError('`num_krylov_vecs` >= `numeig` required!')
@@ -281,12 +283,14 @@ class ShellBackend(base_backend.BaseBackend):
       if not hasattr(A, 'shape'):
         raise AttributeError("`A` has no  attribute `shape`. Cannot initialize "
                              "lanczos. Please provide a valid `initial_state`")
-      return [ShellTensor(tuple()) for _ in range(numeig)
-             ], [ShellTensor(A.shape[0]) for _ in range(numeig)]
+      return [ShellTensor(tuple()) for _ in range(numeig)], [
+          ShellTensor(A.shape[0]) for _ in range(numeig)
+      ]
 
     if initial_state is not None:
-      return [ShellTensor(tuple()) for _ in range(numeig)
-             ], [ShellTensor(initial_state.shape) for _ in range(numeig)]
+      return [ShellTensor(tuple()) for _ in range(numeig)], [
+          ShellTensor(initial_state.shape) for _ in range(numeig)
+      ]
 
     raise ValueError(
         '`A` has no attribut shape adn no `initial_state` is given.')
@@ -295,7 +299,8 @@ class ShellBackend(base_backend.BaseBackend):
     raise NotImplementedError("Shell tensor has not implemented addition( + )")
 
   def subtraction(self, tensor1: Tensor, tensor2: Tensor) -> Tensor:
-    raise NotImplementedError("Shell tensor has not implemented subtraction( - )")
+    raise NotImplementedError(
+        "Shell tensor has not implemented subtraction( - )")
 
   def multiply(self, tensor1: Tensor, tensor2: Tensor) -> Tensor:
     a = np.ones(tensor1.shape)
@@ -315,3 +320,15 @@ class ShellBackend(base_backend.BaseBackend):
           "input to shell backend method `inv` has shape {}. Only matrices are supported."
           .format(matrix.shape))
     return ShellTensor(matrix.shape)
+
+  def broadcast_right_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(tensor2.shape) != 1:
+      raise ValueError(
+          "only order-1 tensors are allowed for `tensor2`, found `tensor2.shape = {}`"
+          .format(tensor2.shape))
+
+    shape2 = tuple(tensor2.shape)
+    if len(shape2) < len(tensor1.shape):
+      shape2 = tuple([1] * (len(tensor1.shape) - len(shape2))) + shape2
+    shape = tuple([max([s1, s2]) for s1, s2 in zip(tensor1.shape, shape2)])
+    return ShellTensor(shape)

--- a/tensornetwork/backends/shell/shell_backend.py
+++ b/tensornetwork/backends/shell/shell_backend.py
@@ -332,3 +332,15 @@ class ShellBackend(base_backend.BaseBackend):
       shape2 = tuple([1] * (len(tensor1.shape) - len(shape2))) + shape2
     shape = tuple([max([s1, s2]) for s1, s2 in zip(tensor1.shape, shape2)])
     return ShellTensor(shape)
+
+  def broadcast_left_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(tensor1.shape) != 1:
+      raise ValueError(
+          "only order-1 tensors are allowed for `tensor1`, found `tensor1.shape = {}`"
+          .format(tensor1.shape))
+
+    shape1 = tuple(tensor1.shape)
+    if len(shape1) < len(tensor2.shape):
+      shape1 = shape1 + tuple([1] * (len(tensor2.shape) - len(shape1)))
+    shape = tuple([max([s1, s2]) for s1, s2 in zip(tensor2.shape, shape1)])
+    return ShellTensor(shape)

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -293,3 +293,19 @@ def test_broadcast_right_multiplication_raises():
   tensor2 = backend.randn((3, 3))
   with pytest.raises(ValueError):
     backend.broadcast_right_multiplication(tensor1, tensor2)
+
+
+def test_broadcast_left_multiplication():
+  backend = shell_backend.ShellBackend()
+  tensor1 = backend.randn((3,))
+  tensor2 = backend.randn((3, 4, 2))
+  out = backend.broadcast_left_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out.shape, [3, 4, 2])
+
+
+def test_broadcast_left_multiplication_raises():
+  backend = shell_backend.ShellBackend()
+  tensor1 = backend.randn((3, 3))
+  tensor2 = backend.randn((3, 4, 2))
+  with pytest.raises(ValueError):
+    backend.broadcast_left_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -284,7 +284,7 @@ def test_broadcast_right_multiplication():
   tensor1 = backend.randn((2, 4, 3))
   tensor2 = backend.randn((3,))
   out = backend.broadcast_right_multiplication(tensor1, tensor2)
-  assert out.shape == [2, 4, 3]
+  np.testing.assert_allclose(out.shape, [2, 4, 3])
 
 
 def test_broadcast_right_multiplication_raises():

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -277,3 +277,19 @@ def test_matrix_inv_raises():
   matrix = backend.randn((4, 4, 4), seed=10)
   with pytest.raises(ValueError):
     backend.inv(matrix)
+
+
+def test_broadcast_right_multiplication():
+  backend = shell_backend.ShellBackend()
+  tensor1 = backend.randn((2, 4, 3))
+  tensor2 = backend.randn((3,))
+  out = backend.broadcast_right_multiplication(tensor1, tensor2)
+  assert out.shape == [2, 4, 3]
+
+
+def test_broadcast_right_multiplication_raises():
+  backend = shell_backend.ShellBackend()
+  tensor1 = backend.randn((2, 4, 3))
+  tensor2 = backend.randn((3, 3))
+  with pytest.raises(ValueError):
+    backend.broadcast_right_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/symmetric/symmetric_backend.py
+++ b/tensornetwork/backends/symmetric/symmetric_backend.py
@@ -196,9 +196,11 @@ class SymmetricBackend(base_backend.BaseBackend):
     if tensor2.ndim != 1:
       raise ValueError("only order-1 tensors are allowed for `tensor2`,"
                        " found `tensor2.shape = {}`".format(tensor2.shape))
-    shape1 = tensor1.shape
-    tmp = self.reshape(tensor1,
-                       (numpy.prod(shape1[:tensor1.ndim - 1]), shape1[-1]))
-    #NOTE (mganahl): we use mulitplication by diagonal matrix here
-    return self.reshape(
-        self.tensordot(tmp, self.diag(tensor2), ([1], [0])), shape1)
+    return self.tensordot(tensor1, self.diag(tensor2),
+                          ([len(tensor1.shape) - 1], [0]))
+
+  def broadcast_left_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(tensor1.shape) != 1:
+      raise ValueError("only order-1 tensors are allowed for `tensor1`,"
+                       " found `tensor1.shape = {}`".format(tensor1.shape))
+    return self.tensordot(self.diag(tensor1), tensor2, ([1], [0]))

--- a/tensornetwork/backends/symmetric/symmetric_backend.py
+++ b/tensornetwork/backends/symmetric/symmetric_backend.py
@@ -191,3 +191,14 @@ class SymmetricBackend(base_backend.BaseBackend):
       raise ValueError("input to symmetric backend method `inv` has shape {}."
                        " Only matrices are supported.".format(matrix.shape))
     return self.bs.inv(matrix)
+
+  def broadcast_right_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if tensor2.ndim != 1:
+      raise ValueError("only order-1 tensors are allowed for `tensor2`,"
+                       " found `tensor2.shape = {}`".format(tensor2.shape))
+    shape1 = tensor1.shape
+    tmp = self.reshape(tensor1,
+                       (numpy.prod(shape1[:tensor1.ndim - 1]), shape1[-1]))
+    #NOTE (mganahl): we use mulitplication by diagonal matrix here
+    return self.reshape(
+        self.tensordot(tmp, self.diag(tensor2), ([1], [0])), shape1)

--- a/tensornetwork/backends/symmetric/symmetric_backend_test.py
+++ b/tensornetwork/backends/symmetric/symmetric_backend_test.py
@@ -739,3 +739,45 @@ def test_broadcast_right_multiplication_raises():
   tensor2 = ChargeArray.random(indices=indices)
   with pytest.raises(ValueError):
     backend.broadcast_right_multiplication(tensor1, tensor2)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+@pytest.mark.parametrize("num_charges", [1, 2])
+def test_broadcast_left_multiplication(dtype, num_charges):
+  np.random.seed(10)
+  backend = symmetric_backend.SymmetricBackend()
+  Ds = [10, 30, 24]
+  R = len(Ds)
+  indices = [
+      Index(
+          BaseCharge(
+              np.random.randint(-5, 6, (num_charges, Ds[n])),
+              charge_types=[U1Charge] * num_charges), False) for n in range(R)
+  ]
+
+  tensor1 = ChargeArray.random(indices=[indices[0]], dtype=dtype)
+  tensor2 = backend.randn(indices, dtype=dtype)
+  t1dense = tensor1.todense()
+  t2dense = tensor2.todense()
+  out = backend.broadcast_left_multiplication(tensor1, tensor2)
+  dense = np.reshape(t1dense, (10, 1, 1)) * t2dense
+  np.testing.assert_allclose(out.todense(), dense)
+
+
+def test_broadcast_left_multiplication_raises():
+  np.random.seed(10)
+  backend = symmetric_backend.SymmetricBackend()
+  num_charges = 1
+  Ds = [10, 30, 24]
+  R = len(Ds)
+  indices = [
+      Index(
+          BaseCharge(
+              np.random.randint(-5, 6, (num_charges, Ds[n])),
+              charge_types=[U1Charge] * num_charges), False) for n in range(R)
+  ]
+
+  tensor1 = ChargeArray.random(indices=indices)
+  tensor2 = backend.randn(indices)
+  with pytest.raises(ValueError):
+    backend.broadcast_left_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -53,10 +53,13 @@ class TensorFlowBackend(base_backend.BaseBackend):
                         max_truncation_error: Optional[float] = None,
                         relative: Optional[bool] = False
                        ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
-    return decompositions.svd_decomposition(self.tf, tensor, split_axis,
-                                            max_singular_values,
-                                            max_truncation_error,
-                                            relative=relative)
+    return decompositions.svd_decomposition(
+        self.tf,
+        tensor,
+        split_axis,
+        max_singular_values,
+        max_truncation_error,
+        relative=relative)
 
   def qr_decomposition(self, tensor: Tensor,
                        split_axis: int) -> Tuple[Tensor, Tensor]:
@@ -144,13 +147,19 @@ class TensorFlowBackend(base_backend.BaseBackend):
     dtype = dtype if dtype is not None else self.tf.float64
     if (dtype is self.tf.complex128) or (dtype is self.tf.complex64):
       return self.tf.complex(
-          self.tf.random.uniform(shape=shape, minval=boundaries[0],
-                                 maxval=boundaries[1], dtype=dtype.real_dtype),
-          self.tf.random.uniform(shape=shape, minval=boundaries[0],
-                                 maxval=boundaries[1], dtype=dtype.real_dtype))
+          self.tf.random.uniform(
+              shape=shape,
+              minval=boundaries[0],
+              maxval=boundaries[1],
+              dtype=dtype.real_dtype),
+          self.tf.random.uniform(
+              shape=shape,
+              minval=boundaries[0],
+              maxval=boundaries[1],
+              dtype=dtype.real_dtype))
     self.tf.random.set_seed(10)
-    a = self.tf.random.uniform(shape=shape, minval=boundaries[0],
-                               maxval=boundaries[1], dtype=dtype)
+    a = self.tf.random.uniform(
+        shape=shape, minval=boundaries[0], maxval=boundaries[1], dtype=dtype)
     return a
 
   def conj(self, tensor: Tensor) -> Tensor:
@@ -171,16 +180,16 @@ class TensorFlowBackend(base_backend.BaseBackend):
     raise NotImplementedError("Backend '{}' has not implemented eigs.".format(
         self.name))
 
-  def eigsh_lanczos(self,
-                    A: Callable,
-                    initial_state: Optional[Tensor] = None,
-                    num_krylov_vecs: Optional[int] = 200,
-                    numeig: Optional[int] = 1,
-                    tol: Optional[float] = 1E-8,
-                    delta: Optional[float] = 1E-8,
-                    ndiag: Optional[int] = 20,
-                    reorthogonalize: Optional[bool] = False
-                   ) -> Tuple[List, List]:
+  def eigsh_lanczos(
+      self,
+      A: Callable,
+      initial_state: Optional[Tensor] = None,
+      num_krylov_vecs: Optional[int] = 200,
+      numeig: Optional[int] = 1,
+      tol: Optional[float] = 1E-8,
+      delta: Optional[float] = 1E-8,
+      ndiag: Optional[int] = 20,
+      reorthogonalize: Optional[bool] = False) -> Tuple[List, List]:
     raise NotImplementedError(
         "Backend '{}' has not implemented eighs_lanczos.".format(self.name))
 
@@ -207,3 +216,11 @@ class TensorFlowBackend(base_backend.BaseBackend):
           "input to tensorflow backend method `inv` has shape {}. Only matrices are supported."
           .format(self.tf.shape(matrix)))
     return self.tf.linalg.inv(matrix)
+
+  def broadcast_right_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(self.tf.shape(tensor2)) != 1:
+      raise ValueError(
+          "only order-1 tensors are allowed for `tensor2`, found `tensor2.shape = {}`"
+          .format(tensor2.shape))
+
+    return tensor1 * tensor2

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -212,15 +212,26 @@ class TensorFlowBackend(base_backend.BaseBackend):
 
   def inv(self, matrix: Tensor) -> Tensor:
     if len(self.tf.shape(matrix)) > 2:
-      raise ValueError(
-          "input to tensorflow backend method `inv` has shape {}. Only matrices are supported."
-          .format(self.tf.shape(matrix)))
+      raise ValueError("input to tensorflow backend method `inv` has shape {}. "
+                       "Only matrices are supported.".format(
+                           self.tf.shape(matrix)))
     return self.tf.linalg.inv(matrix)
 
   def broadcast_right_multiplication(self, tensor1: Tensor, tensor2: Tensor):
     if len(self.tf.shape(tensor2)) != 1:
-      raise ValueError(
-          "only order-1 tensors are allowed for `tensor2`, found `tensor2.shape = {}`"
-          .format(tensor2.shape))
+      raise ValueError("only order-1 tensors are allowed for `tensor2`, "
+                       "found `tensor2.shape = {}`".format(
+                           self.tf.shape(tensor2)))
 
     return tensor1 * tensor2
+
+  def broadcast_left_multiplication(self, tensor1: Tensor, tensor2: Tensor):
+    if len(self.tf.shape(tensor1)) != 1:
+      raise ValueError("only order-1 tensors are allowed for `tensor1`,"
+                       " found `tensor1.shape = {}`".format(
+                           self.tf.shape(tensor1)))
+
+    t1_broadcast_shape = self.shape_concat(
+        [self.shape_tensor(tensor1), [1] * (len(self.tf.shape(tensor2)) - 1)],
+        axis=-1)
+    return tensor2 * self.reshape(tensor1, t1_broadcast_shape)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -374,3 +374,21 @@ def test_broadcast_right_multiplication_raises():
   tensor2 = backend.randn((3, 3), dtype=dtype, seed=10)
   with pytest.raises(ValueError):
     backend.broadcast_right_multiplication(tensor1, tensor2)
+
+
+@pytest.mark.parametrize("dtype", [tf.float64, tf.complex128])
+def test_broadcast_left_multiplication(dtype):
+  backend = tensorflow_backend.TensorFlowBackend()
+  tensor1 = backend.randn((3,), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3, 4, 2), dtype=dtype, seed=10)
+  out = backend.broadcast_left_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out, np.reshape(tensor1, (3, 1, 1)) * tensor2)
+
+
+def test_broadcast_left_multiplication_raises():
+  dtype = tf.float64
+  backend = tensorflow_backend.TensorFlowBackend()
+  tensor1 = backend.randn((3, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    backend.broadcast_left_multiplication(tensor1, tensor2)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -248,7 +248,8 @@ def test_conj():
 
 @pytest.mark.parametrize("a, b, expected", [
     pytest.param(1, 1, 2),
-    pytest.param(2.*np.ones(()), 1.*np.ones((1, 2, 3)), 3.*np.ones((1, 2, 3))),
+    pytest.param(2. * np.ones(()), 1. * np.ones((1, 2, 3)), 3. * np.ones(
+        (1, 2, 3))),
 ])
 def test_addition(a, b, expected):
   backend = tensorflow_backend.TensorFlowBackend()
@@ -290,7 +291,8 @@ def test_multiply(a, b, expected):
 
 @pytest.mark.parametrize("a, b, expected", [
     pytest.param(2., 2., 1.),
-    pytest.param(np.ones(()), 2.*np.ones((1, 2, 3)), 0.5*np.ones((1, 2, 3))),
+    pytest.param(
+        np.ones(()), 2. * np.ones((1, 2, 3)), 0.5 * np.ones((1, 2, 3))),
 ])
 def test_divide(a, b, expected):
   backend = tensorflow_backend.TensorFlowBackend()
@@ -343,6 +345,7 @@ def test_matrix_inv_raises(dtype):
   with pytest.raises(ValueError):
     backend.inv(matrix)
 
+
 def test_eigs_not_implemented():
   backend = tensorflow_backend.TensorFlowBackend()
   with pytest.raises(NotImplementedError):
@@ -353,3 +356,21 @@ def test_eigsh_lanczos_not_implemented():
   backend = tensorflow_backend.TensorFlowBackend()
   with pytest.raises(NotImplementedError):
     backend.eigsh_lanczos(np.ones((2, 2)))
+
+
+@pytest.mark.parametrize("dtype", [tf.float64, tf.complex128])
+def test_broadcast_right_multiplication(dtype):
+  backend = tensorflow_backend.TensorFlowBackend()
+  tensor1 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3,), dtype=dtype, seed=10)
+  out = backend.broadcast_right_multiplication(tensor1, tensor2)
+  np.testing.assert_allclose(out, tensor1 * tensor2)
+
+
+def test_broadcast_right_multiplication_raises():
+  dtype = tf.float64
+  backend = tensorflow_backend.TensorFlowBackend()
+  tensor1 = backend.randn((2, 4, 3), dtype=dtype, seed=10)
+  tensor2 = backend.randn((3, 3), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    backend.broadcast_right_multiplication(tensor1, tensor2)


### PR DESCRIPTION
for broadcasting `a*b`, with `a`  a 1d vector, and `b` a matrix (eq. to `np.diag(a).dot(b)`)