### PR TITLE
add sin cos exp log expm to backends

### DIFF
--- a/tensornetwork/backends/backend_test.py
+++ b/tensornetwork/backends/backend_test.py
@@ -350,3 +350,33 @@ def test_base_backend_inv_not_implemented():
   backend = BaseBackend()
   with pytest.raises(NotImplementedError):
     backend.inv(np.ones((2, 2)))
+
+
+def test_base_backend_sin_not_implemented():
+  backend = BaseBackend()
+  with pytest.raises(NotImplementedError):
+    backend.sin(np.ones((2, 2)))
+
+
+def test_base_backend_cos_not_implemented():
+  backend = BaseBackend()
+  with pytest.raises(NotImplementedError):
+    backend.cos(np.ones((2, 2)))
+
+
+def test_base_backend_exp_not_implemented():
+  backend = BaseBackend()
+  with pytest.raises(NotImplementedError):
+    backend.exp(np.ones((2, 2)))
+
+
+def test_base_backend_log_not_implemented():
+  backend = BaseBackend()
+  with pytest.raises(NotImplementedError):
+    backend.log(np.ones((2, 2)))
+
+
+def test_base_backend_expm_not_implemented():
+  backend = BaseBackend()
+  with pytest.raises(NotImplementedError):
+    backend.expm(np.ones((2, 2)))

--- a/tensornetwork/backends/base_backend.py
+++ b/tensornetwork/backends/base_backend.py
@@ -416,7 +416,7 @@ class BaseBackend:
 
   def addition(self, tensor1: Tensor, tensor2: Tensor) -> Tensor:
     """
-      Return the default multiplication of `tensor`.
+      Return the default addition of `tensor`.
       A backend can override such implementation.
       Args:
         tensor1: A tensor.
@@ -429,7 +429,7 @@ class BaseBackend:
 
   def subtraction(self, tensor1: Tensor, tensor2: Tensor) -> Tensor:
     """
-      Return the default multiplication of `tensor`.
+      Return the default substraction of `tensor`.
       A backend can override such implementation.
       Args:
         tensor1: A tensor.
@@ -520,4 +520,64 @@ class BaseBackend:
     """
     raise NotImplementedError(
         "Backend '{}' has not implemented `broadcast_left_multiplication`."
+        .format(self.name))
+
+  def sin(self, tensor: Tensor):
+    """
+    Return sin of `tensor`.
+    Args:
+      tensor: A tensor.
+    Returns:
+      Tensor
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented `sin`."
+        .format(self.name))
+
+  def cos(self, tensor: Tensor):
+    """
+    Return cos of `tensor`.
+    Args:
+      tensor: A tensor.
+    Returns:
+      Tensor
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented `cos`."
+        .format(self.name))
+
+  def exp(self, tensor: Tensor):
+    """
+    Return elementwise exp of `tensor`.
+    Args:
+      tensor: A tensor.
+    Returns:
+      Tensor
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented `exp`."
+        .format(self.name))
+
+  def log(self, tensor: Tensor):
+    """
+    Return elementwise natural logarithm of `tensor`.
+    Args:
+      tensor: A tensor.
+    Returns:
+      Tensor
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented `log`."
+        .format(self.name))
+
+  def expm(self, matrix: Tensor):
+    """
+    Return expm log of `matrix`, matrix exponential.
+    Args:
+      matrix: A tensor.
+    Returns:
+      Tensor
+    """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented `expm`."
         .format(self.name))

--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -32,6 +32,7 @@ class JaxBackend(numpy_backend.NumPyBackend):
                         "backend or install Jax.")
     self.jax = jax
     self.np = self.jax.numpy
+    self.sp = self.jax.scipy
     self.name = "jax"
     self._dtype = np.dtype(dtype) if dtype is not None else None
 

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -2,6 +2,7 @@
 """Tests for graphmode_tensornetwork."""
 import tensorflow as tf
 import numpy as np
+import scipy as sp
 import jax
 import pytest
 from tensornetwork.backends.jax import jax_backend
@@ -350,3 +351,40 @@ def test_sparse_shape():
   backend = jax_backend.JaxBackend()
   tensor = backend.randn((2, 3, 4), dtype=dtype, seed=10)
   np.testing.assert_allclose(backend.sparse_shape(tensor), tensor.shape)
+
+
+@pytest.mark.parametrize("dtype,method",
+                         [(np.float64, "sin"), (np.complex128, "sin"),
+                          (np.float64, "cos"), (np.complex128, "cos"),
+                          (np.float64, "exp"), (np.complex128, "exp"),
+                          (np.float64, "log"), (np.complex128, "log")])
+def test_elementwise_ops(dtype, method):
+  backend = jax_backend.JaxBackend()
+  tensor = backend.randn((4, 3, 2), dtype=dtype, seed=10)
+  if method == "log":
+    tensor = np.abs(tensor)
+  tensor1 = getattr(backend, method)(tensor)
+  tensor2 = getattr(np, method)(tensor)
+  np.testing.assert_almost_equal(tensor1, tensor2)
+
+
+@pytest.mark.parametrize("dtype,method",
+                         [(np.float64, "expm"), (np.complex128, "expm")])
+def test_matrix_ops(dtype, method):
+  backend = jax_backend.JaxBackend()
+  matrix = backend.randn((4, 4), dtype=dtype, seed=10)
+  matrix1 = getattr(backend, method)(matrix)
+  matrix2 = getattr(sp.linalg, method)(matrix)
+  np.testing.assert_almost_equal(matrix1, matrix2)
+
+
+@pytest.mark.parametrize("dtype,method",
+                         [(np.float64, "expm"), (np.complex128, "expm")])
+def test_matrix_ops_raises(dtype, method):
+  backend = jax_backend.JaxBackend()
+  matrix = backend.randn((4, 4, 4), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    getattr(backend, method)(matrix)
+  matrix = backend.randn((4, 3), dtype=dtype, seed=10)
+  with pytest.raises(ValueError):
+    getattr(backend, method)(matrix)

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -383,8 +383,8 @@ def test_matrix_ops(dtype, method):
 def test_matrix_ops_raises(dtype, method):
   backend = jax_backend.JaxBackend()
   matrix = backend.randn((4, 4, 4), dtype=dtype, seed=10)
-  with pytest.raises(ValueError):
+  with pytest.raises(ValueError, match=r".*Only matrices.*"):
     getattr(backend, method)(matrix)
   matrix = backend.randn((4, 3), dtype=dtype, seed=10)
-  with pytest.raises(ValueError):
+  with pytest.raises(ValueError, match=r".*N\*N matrix.*"):
     getattr(backend, method)(matrix)

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -17,6 +17,7 @@ from tensornetwork.backends import base_backend
 from tensornetwork.backends.numpy import decompositions
 import numpy
 import scipy
+from scipy import linalg
 Tensor = Any
 
 
@@ -27,8 +28,6 @@ class NumPyBackend(base_backend.BaseBackend):
     super(NumPyBackend, self).__init__()
     self.np = numpy
     self.sp = scipy
-    # pylint: disable=import-outside-toplevel
-    from scipy import linalg
     self.sp.linalg = linalg
     self.name = "numpy"
 

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -26,6 +26,9 @@ class NumPyBackend(base_backend.BaseBackend):
   def __init__(self):
     super(NumPyBackend, self).__init__()
     self.np = numpy
+    self.sp = scipy
+    from scipy import linalg
+    self.sp.linalg = linalg
     self.name = "numpy"
 
   def tensordot(self, a: Tensor, b: Tensor, axes: Sequence[Sequence[int]]):
@@ -433,3 +436,25 @@ class NumPyBackend(base_backend.BaseBackend):
     t1_broadcast_shape = self.shape_concat(
         [self.shape_tensor(tensor1), [1] * (len(tensor2.shape) - 1)], axis=-1)
     return tensor2 * self.reshape(tensor1, t1_broadcast_shape)
+
+  def sin(self, tensor: Tensor):
+    return self.np.sin(tensor)
+
+  def cos(self, tensor: Tensor):
+    return self.np.cos(tensor)
+
+  def exp(self, tensor: Tensor):
+    return self.np.exp(tensor)
+
+  def log(self, tensor: Tensor):
+    return self.np.log(tensor)
+
+  def expm(self, matrix: Tensor):
+    if len(matrix.shape) != 2:
+      raise ValueError("input to numpy backend method `expm` has shape {}."
+                       " Only matrices are supported.".format(matrix.shape))
+    if matrix.shape[0] != matrix.shape[1]:
+      raise ValueError("input to numpy backend method `expm` only supports"
+                       " N*N matrix, {x}*{y} matrix is given"
+                       .format(x=matrix.shape[0], y=matrix.shape[1]))
+    return self.sp.linalg.expm(matrix)

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -27,6 +27,7 @@ class NumPyBackend(base_backend.BaseBackend):
     super(NumPyBackend, self).__init__()
     self.np = numpy
     self.sp = scipy
+    # pylint: disable=import-outside-toplevel
     from scipy import linalg
     self.sp.linalg = linalg
     self.name = "numpy"

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -699,8 +699,8 @@ def test_matrix_ops(dtype, method):
 def test_matrix_ops_raises(dtype, method):
   backend = numpy_backend.NumPyBackend()
   matrix = backend.randn((4, 4, 4), dtype=dtype, seed=10)
-  with pytest.raises(ValueError):
+  with pytest.raises(ValueError, match=r".*Only matrices.*"):
     getattr(backend, method)(matrix)
   matrix = backend.randn((4, 3), dtype=dtype, seed=10)
-  with pytest.raises(ValueError):
+  with pytest.raises(ValueError, match=r".*N\*N matrix.*"):
     getattr(backend, method)(matrix)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -247,3 +247,25 @@ class TensorFlowBackend(base_backend.BaseBackend):
         [self.shape_tensor(tensor1), [1] * (len(self.tf.shape(tensor2)) - 1)],
         axis=-1)
     return tensor2 * self.reshape(tensor1, t1_broadcast_shape)
+
+  def sin(self, tensor: Tensor):
+    return self.tf.math.sin(tensor)
+
+  def cos(self, tensor: Tensor):
+    return self.tf.math.cos(tensor)
+
+  def exp(self, tensor: Tensor):
+    return self.tf.math.exp(tensor)
+
+  def log(self, tensor: Tensor):
+    return self.tf.math.log(tensor)
+
+  def expm(self, matrix: Tensor):
+    if len(matrix.shape) != 2:
+      raise ValueError("input to tensorflow backend method `expm` has shape {}."
+                       " Only matrices are supported.".format(matrix.shape))
+    if matrix.shape[0] != matrix.shape[1]:
+      raise ValueError("input to tensorflow backend method `expm` only supports"
+                       "N*N matrix, {x}*{y} matrix is given"
+                       .format(x=matrix.shape[0], y=matrix.shape[1]))
+    return self.tf.linalg.expm(matrix)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -444,8 +444,8 @@ def test_matrix_ops(dtype, method):
 def test_matrix_ops_raises(dtype, method):
   backend = tensorflow_backend.TensorFlowBackend()
   matrix = backend.randn((4, 4, 4), dtype=dtype, seed=10)
-  with pytest.raises(ValueError):
+  with pytest.raises(ValueError, match=r".*Only matrices.*"):
     getattr(backend, method)(matrix)
   matrix = backend.randn((4, 3), dtype=dtype, seed=10)
-  with pytest.raises(ValueError):
+  with pytest.raises(ValueError, match=r".*N\*N matrix.*"):
     getattr(backend, method)(matrix)


### PR DESCRIPTION
If this is ok, I can add more element wise and matrix ops later such as tan, cosh, sinm and so on. maybe we need to consider generating these methods dynamically since they follows the same pattern.

I implemented these methods in numpy, jax and tensorflow backends. I don't add torch one since I always need complex numbers, but impl with pytorch should be straightforward.