### PR TITLE
changed gate edge order in base_mps, apply_two_site_gate

### DIFF
--- a/tensornetwork/matrixproductstates/base_mps.py
+++ b/tensornetwork/matrixproductstates/base_mps.py
@@ -483,10 +483,10 @@ class BaseMPS:
     node1 = Node(self.tensors[site1], backend=self.backend)
     node2 = Node(self.tensors[site2], backend=self.backend)
     node1[2] ^ node2[0]
-    gate_node[2] ^ node1[1]
-    gate_node[3] ^ node2[1]
-    left_edges = [node1[0], gate_node[0]]
-    right_edges = [gate_node[1], node2[2]]
+    gate_node[0] ^ node1[1]
+    gate_node[2] ^ node2[1]
+    left_edges = [node1[0], gate_node[1]]
+    right_edges = [gate_node[3], node2[2]]
     result = node1 @ node2 @ gate_node
     U, S, V, tw = split_node_full_svd(
         result,


### PR DESCRIPTION
Currently, the input gate edges are said to be gate_node[2] and gate_node[3], while the output edges are gate_node[0], and gate_node[1].

This is giving me errors, as when I define my gate as a 2x2x2x2 numpy array, and then convert it to a tensor node, the input edges that works for me is gate_node[0], and gate_node[2], with gate_node[1], and gate_node[3] as output.

So hence for my code to work, I need to reorder the edges each time.
I say my code, but I think this applies generally as I just use the 

gate_node = numpy.tensordot(X,Y,axes=0) and 
gate_node = tn.Node(gate_node) 
commands to create my gate, and there is no edge specification from my end.