### PR TITLE
Pivot handles pivot_axis=-1 correctly, tests improved

### DIFF
--- a/tensornetwork/backends/abstract_backend.py
+++ b/tensornetwork/backends/abstract_backend.py
@@ -812,7 +812,7 @@ class AbstractBackend:
     raise NotImplementedError(
         "Backend '{}' has not implemented `sign`.".format(self.name))
 
-  def pivot(self, tensor: Tensor, pivot_axis: int = 1) -> Tensor:
+  def pivot(self, tensor: Tensor, pivot_axis: int = -1) -> Tensor:
     """ Reshapes a tensor into a matrix, whose columns (rows) are the
     vectorized dimensions to the left (right) of pivot_axis.
 
@@ -827,7 +827,7 @@ class AbstractBackend:
       The pivoted tensor.
     """
     ndim = len(self.shape_tuple(tensor))
-    if pivot_axis < 1 or pivot_axis > ndim:
+    if pivot_axis > ndim:
       errstr = f"pivot_axis = {pivot_axis} was invalid given ndim={ndim} array."
       raise ValueError(errstr)
 

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -837,13 +837,13 @@ def test_sign(dtype):
   np.testing.assert_allclose(expected, actual)
 
 
+@pytest.mark.parametrize("pivot_axis", [-1, 1, 2])
 @pytest.mark.parametrize("dtype", np_dtypes)
-def test_pivot(dtype):
+def test_pivot(dtype, pivot_axis):
   shape = (4, 3, 2, 8)
+  pivot_shape = (np.prod(shape[:pivot_axis]), np.prod(shape[pivot_axis:]))
   backend = jax_backend.JaxBackend()
   tensor = backend.randn(shape, dtype=dtype, seed=10)
-  cols = 12
-  rows = 16
-  expected = tensor.reshape((cols, rows))
-  actual = backend.pivot(tensor, pivot_axis=2)
+  expected = tensor.reshape(pivot_shape)
+  actual = backend.pivot(tensor, pivot_axis=pivot_axis)
   np.testing.assert_allclose(expected, actual)

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -894,14 +894,13 @@ def test_trace(dtype, offset, axis1, axis2):
     expected = np.trace(array, offset=offset, axis1=axis1, axis2=axis2)
     np.testing.assert_allclose(actual, expected)
 
-
+@pytest.mark.parametrize("pivot_axis", [-1, 1, 2])
 @pytest.mark.parametrize("dtype", np_dtypes)
-def test_pivot(dtype):
+def test_pivot(dtype, pivot_axis):
   shape = (4, 3, 2, 8)
+  pivot_shape = (np.prod(shape[:pivot_axis]), np.prod(shape[pivot_axis:]))
   backend = numpy_backend.NumPyBackend()
   tensor = backend.randn(shape, dtype=dtype, seed=10)
-  cols = 12
-  rows = 16
-  expected = tensor.reshape((cols, rows))
-  actual = backend.pivot(tensor, pivot_axis=2)
+  expected = tensor.reshape(pivot_shape)
+  actual = backend.pivot(tensor, pivot_axis=pivot_axis)
   np.testing.assert_allclose(expected, actual)

--- a/tensornetwork/backends/pytorch/pytorch_backend_test.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend_test.py
@@ -622,15 +622,15 @@ def test_trace_raises():
     _ = backend.trace(array)
 
 
+@pytest.mark.parametrize("pivot_axis", [-1, 1, 2])
 @pytest.mark.parametrize("dtype", torch_randn_dtypes)
-def test_pivot(dtype):
+def test_pivot(dtype, pivot_axis):
   shape = (4, 3, 2, 8)
+  pivot_shape = (np.prod(shape[:pivot_axis]), np.prod(shape[pivot_axis:]))
   backend = pytorch_backend.PyTorchBackend()
   tensor = backend.randn(shape, dtype=dtype, seed=10)
-  cols = 12
-  rows = 16
-  expected = torch.reshape(tensor, (cols, rows))
-  actual = backend.pivot(tensor, pivot_axis=2)
+  expected = torch.reshape(tensor, pivot_shape)
+  actual = backend.pivot(tensor, pivot_axis=pivot_axis)
   np.testing.assert_allclose(expected, actual)
 
 

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -454,11 +454,13 @@ def test_matmul():
   np.testing.assert_allclose(actual.shape, [10, 2, 4])
 
 
-def test_pivot():
+@pytest.mark.parametrize("pivot_axis", [-1, 1, 2])
+def test_pivot(pivot_axis):
   shape = (4, 3, 2, 8)
   backend = numpy_backend.NumPyBackend()
+  pivot_shape = (np.prod(shape[:pivot_axis]), np.prod(shape[pivot_axis:]))
   tensor = backend.randn(shape, dtype=np.float64)
   cols = 12
   rows = 16
-  actual = backend.pivot(tensor, pivot_axis=2)
-  np.testing.assert_allclose(actual.shape, (cols, rows))
+  actual = backend.pivot(tensor, pivot_axis=pivot_axis)
+  np.testing.assert_allclose(actual.shape, pivot_shape)

--- a/tensornetwork/backends/shell/shell_backend_test.py
+++ b/tensornetwork/backends/shell/shell_backend_test.py
@@ -460,7 +460,5 @@ def test_pivot(pivot_axis):
   backend = numpy_backend.NumPyBackend()
   pivot_shape = (np.prod(shape[:pivot_axis]), np.prod(shape[pivot_axis:]))
   tensor = backend.randn(shape, dtype=np.float64)
-  cols = 12
-  rows = 16
   actual = backend.pivot(tensor, pivot_axis=pivot_axis)
   np.testing.assert_allclose(actual.shape, pivot_shape)

--- a/tensornetwork/backends/symmetric/symmetric_backend.py
+++ b/tensornetwork/backends/symmetric/symmetric_backend.py
@@ -355,5 +355,5 @@ class SymmetricBackend(abstract_backend.AbstractBackend):
       raise ValueError(f"axis1 = {axis1} cannot equal axis2 = {axis2}")
     return self.bs.trace(tensor, (axis1, axis2))
 
-  def pivot(self, tensor: Tensor, pivot_axis: int = 1) -> Tensor:
+  def pivot(self, tensor: Tensor, pivot_axis: int = -1) -> Tensor:
     raise NotImplementedError("Symmetric backend doesn't support pivot.")

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -570,13 +570,13 @@ def test_trace(dtype, offset, axis1, axis2):
     np.testing.assert_allclose(actual, expected, rtol=tol, atol=tol)
 
 
+@pytest.mark.parametrize("pivot_axis", [-1, 1, 2])
 @pytest.mark.parametrize("dtype", tf_dtypes)
-def test_pivot(dtype):
+def test_pivot(dtype, pivot_axis):
   shape = (4, 3, 2, 8)
+  pivot_shape = (np.prod(shape[:pivot_axis]), np.prod(shape[pivot_axis:]))
   backend = tensorflow_backend.TensorFlowBackend()
   tensor = backend.randn(shape, dtype=dtype, seed=10)
-  cols = 12
-  rows = 16
-  expected = tf.reshape(tensor, (cols, rows))
-  actual = backend.pivot(tensor, pivot_axis=2)
+  expected = tf.reshape(tensor, pivot_shape)
+  actual = backend.pivot(tensor, pivot_axis=pivot_axis)
   np.testing.assert_allclose(expected, actual)


### PR DESCRIPTION
- Removes error trap that excluded the pivot_axis = -1 case.
- Tests of pivot cover several choices of pivot_axis.