### PR TITLE
Improved krylov

### DIFF
--- a/tensornetwork/linalg/krylov.py
+++ b/tensornetwork/linalg/krylov.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #pylint: disable=line-too-long
 from typing import Optional, Sequence, Tuple, Any, Union, Type, Callable, List, Text
+import functools
 import numpy as np
 import tensornetwork.tensor
 import tensornetwork.backends.abstract_backend as abstract_backend
@@ -23,10 +24,87 @@ AbstractBackend = abstract_backend.AbstractBackend
 Array = Any
 Tensor = tensornetwork.tensor.Tensor
 
+class MatvecCache:
+  """
+  Caches matvec functions so that they have identical function signature
+  when called repeatedly. This circumvents extraneous recompilations when
+  Jit is used. Incoming matvec functions should be in terms of Tensor
+  and have function signature A = matvec(x, *args), where each of the
+  positional arguments in *args is also a Tensor.
+  """
+  def __init__(self):
+    self.clear()
+
+  def clear(self):
+    self.cache = {}
+
+  def retrieve(self, backend_name: Text, matvec: Callable):
+    if backend_name not in self.cache:
+      self.cache[backend_name] = {}
+    if matvec not in self.cache[backend_name]:
+      def wrapped(x, *args):
+        X = Tensor(x, backend=backend_name)
+        Args = [Tensor(a, backend=backend_name) for a in args]
+        Y = matvec(X, *Args)
+        return Y.array
+      self.cache[backend_name][matvec] = wrapped
+    return self.cache[backend_name][matvec]
+
+KRYLOV_MATVEC_CACHE = MatvecCache()
+
+def krylov_error_checks(backend: Union[Text, AbstractBackend, None],
+                        x0: Union[Tensor, None],
+                        args: Union[List[Tensor], None]):
+  """
+  Checks that at least one of backend and x0 are not None; that backend
+  and x0.backend agree; that if args is not None its elements are Tensors
+  whose backends also agree. Creates a backend object from backend
+  and returns the arrays housed by x0 and args.
+
+  Args:
+    backend: A backend, text specifying one, or None.
+    x0: A tn.Tensor, or None.
+    args: A list of tn.Tensor, or None.
+  Returns:
+    backend: A backend object.
+    x0_array: x0.array if x0 was supplied, or None.
+    args_arr: Each array in the list of args if it was supplied, or None.
+  """
+  if backend is None:
+    if x0 is None:
+      raise ValueError("One of backend or x0 must be specified.")
+    backend = x0.backend
+  else:
+    backend = backends.backend_factory.get_backend(backend)
+
+  if x0 is not None:
+    try:
+      x0_array = x0.array
+    except AttributeError():
+      raise TypeError("x0 must be a tn.Tensor.")
+
+    if x0.backend.name != backend.name:
+      errstr = (f"If both x0 and backend are specified the"
+                "backends must agree. \n"
+                "x0 backend: {x0.backend.name} \n"
+                "backend: {backend.name} \n")
+      raise ValueError(errstr)
+  else:
+    x0_array = None
+
+  if args is not None:
+    try:
+      args_array = [a.array for a in args]
+    except AttributeError():
+      raise TypeError("Every element of args must be a tn.Tensor.")
+  else:
+    args_array = args
+  return (backend, x0_array, args_array)
+
 def eigsh_lanczos(A: Callable,
                   backend: Optional[Union[Text, AbstractBackend]] = None,
                   args: Optional[List[Tensor]] = None,
-                  initial_state: Optional[Tensor] = None,
+                  x0: Optional[Tensor] = None,
                   shape: Optional[Tuple[int, ...]] = None,
                   dtype: Optional[Type[np.number]] = None,
                   num_krylov_vecs: int = 20,
@@ -43,11 +121,11 @@ def eigsh_lanczos(A: Callable,
        Call signature of `A` is `res = A(vector, *args)`, where `vector`
        can be an arbitrary `Array`, and `res.shape` has to be `vector.shape`.
     arsg: A list of arguments to `A`.  `A` will be called as
-      `res = A(initial_state, *args)`.
-    initial_state: An initial vector for the Lanczos algorithm. If `None`,
+      `res = A(x0, *args)`.
+    x0: An initial vector for the Lanczos algorithm. If `None`,
       a random initial vector is created using the `backend.randn` method
     shape: The shape of the input-dimension of `A`.
-    dtype: The dtype of the input `A`. If both no `initial_state` is provided,
+    dtype: The dtype of the input `A`. If both no `x0` is provided,
       a random initial state with shape `shape` and dtype `dtype` is created.
     num_krylov_vecs: The number of iterations (number of krylov vectors).
     numeig: The nummber of eigenvector-eigenvalue pairs to be computed.
@@ -70,15 +148,10 @@ def eigsh_lanczos(A: Callable,
      eigvals: A list of `numeig` lowest eigenvalues
      eigvecs: A list of `numeig` lowest eigenvectors
   """
-  if backend is None:
-    backend = backend_contextmanager.get_default_backend()
-  backend = backends.backend_factory.get_backend(backend)
-  if args is not None:
-    args = [a.array for a in args]
-  if initial_state is not None:
-    initial_state = initial_state.array
-  result = backend.eigsh_lanczos(A, args=args,
-                                 initial_state=initial_state,
+  backend, x0_array, args_array = krylov_error_checks(backend, x0, args)
+  mv = KRYLOV_MATVEC_CACHE.retrieve(backend.name, A)
+  result = backend.eigsh_lanczos(mv, args=args_array,
+                                 initial_state=x0_array,
                                  shape=shape, dtype=dtype,
                                  num_krylov_vecs=num_krylov_vecs, numeig=numeig,
                                  tol=tol, delta=delta, ndiag=ndiag,
@@ -91,7 +164,7 @@ def eigsh_lanczos(A: Callable,
 def eigs(A: Callable,
          backend: Optional[Union[Text, AbstractBackend]] = None,
          args: Optional[List[Tensor]] = None,
-         initial_state: Optional[Tensor] = None,
+         x0: Optional[Tensor] = None,
          shape: Optional[Tuple[int, ...]] = None,
          dtype: Optional[Type[np.number]] = None,
          num_krylov_vecs: int = 20,
@@ -107,11 +180,11 @@ def eigs(A: Callable,
        Call signature of `A` is `res = A(vector, *args)`, where `vector`
        can be an arbitrary `Array`, and `res.shape` has to be `vector.shape`.
     arsg: A list of arguments to `A`.  `A` will be called as
-      `res = A(initial_state, *args)`.
-    initial_state: An initial vector for the Lanczos algorithm. If `None`,
+      `res = A(x0, *args)`.
+    x0: An initial vector for the Lanczos algorithm. If `None`,
       a random initial vector is created using the `backend.randn` method
     shape: The shape of the input-dimension of `A`.
-    dtype: The dtype of the input `A`. If both no `initial_state` is provided,
+    dtype: The dtype of the input `A`. If both no `x0` is provided,
       a random initial state with shape `shape` and dtype `dtype` is created.
     num_krylov_vecs: The number of iterations (number of krylov vectors).
     numeig: The nummber of eigenvector-eigenvalue pairs to be computed.
@@ -134,14 +207,9 @@ def eigs(A: Callable,
      eigvals: A list of `numeig` lowest eigenvalues
      eigvecs: A list of `numeig` lowest eigenvectors
   """
-  if backend is None:
-    backend = backend_contextmanager.get_default_backend()
-  backend = backends.backend_factory.get_backend(backend)
-  if args is not None:
-    args = [a.array for a in args]
-  if initial_state is not None:
-    initial_state = initial_state.array
-  result = backend.eigs(A, args=args, initial_state=initial_state,
+  backend, x0_array, args_array = krylov_error_checks(backend, x0, args)
+  mv = KRYLOV_MATVEC_CACHE.retrieve(backend.name, A)
+  result = backend.eigs(mv, args=args_array, initial_state=x0_array,
                         shape=shape, dtype=dtype,
                         num_krylov_vecs=num_krylov_vecs, numeig=numeig,
                         tol=tol, which=which, maxiter=maxiter)
@@ -234,14 +302,17 @@ def gmres(A_mv: Callable,
     x       : The converged solution. It has the same shape as `b`.
     info    : 0 if convergence was achieved, the number of restarts otherwise.
   """
-  if A_args is not None:
-    A_args = [a.array for a in A_args]
-  if x0 is not None:
-    x0 = x0.array
-  out = b.backend.gmres(A_mv, b.array, A_args=A_args,
-                        x0=x0, tol=tol, atol=atol,
-                        num_krylov_vectors=num_krylov_vectors,
-                        maxiter=maxiter, M=M)
+  try:
+    b_array = b.array
+  except AttributeError:
+    raise TypeError("b must be a tn.Tensor")
+  backend, x0_array, args_array = krylov_error_checks(b.backend, x0, A_args)
+
+  mv = KRYLOV_MATVEC_CACHE.retrieve(backend.name, A_mv)
+  out = backend.gmres(mv, b_array, A_args=args_array,
+                      x0=x0_array, tol=tol, atol=atol,
+                      num_krylov_vectors=num_krylov_vectors,
+                      maxiter=maxiter, M=M)
   result, info = out
   resultT = Tensor(result, backend=b.backend)
   return (resultT, info)

--- a/tensornetwork/linalg/tests/test_linalg.py
+++ b/tensornetwork/linalg/tests/test_linalg.py
@@ -125,33 +125,88 @@ def test_norm_vs_backend(backend, dtype):
 
 @pytest.mark.parametrize("sparse_backend", sparse_backends + ["pytorch",])
 @pytest.mark.parametrize("dtype", np_float_dtypes)
+def test_matvec_cache(sparse_backend, dtype):
+  shape = (4, 4)
+  dtype = np_dtype_to_backend(sparse_backend, dtype)
+  A = tensornetwork.linalg.initialization.ones(shape,
+                                               backend=sparse_backend,
+                                               dtype=dtype)
+  B = -1.3 * tensornetwork.linalg.initialization.ones(shape,
+                                                      backend=sparse_backend,
+                                                      dtype=dtype)
+  def matvec(B, A):
+    return A @ B
+
+  def matvec_array(B, A):
+    return A.array @ B.array
+
+  matvec_cache = tensornetwork.linalg.krylov.MatvecCache()
+  mv = matvec_cache.retrieve(sparse_backend, matvec)
+  result = mv(B.array, A.array)
+  test = matvec_array(B, A)
+  assert np.all(np.isfinite(np.ravel(result)))
+  np.testing.assert_allclose(result, test)
+
+
+def test_eigsh_lanczos_raises():
+  n = 2
+  shape = (n, n)
+  tensor = tensornetwork.linalg.initialization.ones(shape,
+                                                    backend="jax",
+                                                    dtype=np.float64)
+
+  def matvec(B):
+    return tensor @ B
+  with pytest.raises(ValueError):
+    _ = tensornetwork.linalg.krylov.eigsh_lanczos(matvec,
+                                                  backend=None,
+                                                  x0=None)
+  with pytest.raises(ValueError):
+    _ = tensornetwork.linalg.krylov.eigsh_lanczos(matvec,
+                                                  backend="numpy",
+                                                  x0=tensor)
+  with pytest.raises(TypeError):
+    _ = tensornetwork.linalg.krylov.eigsh_lanczos(matvec,
+                                                  backend="numpy",
+                                                  x0=
+                                                  tensor.array)
+  with pytest.raises(TypeError):
+    _ = tensornetwork.linalg.krylov.eigsh_lanczos(matvec,
+                                                  backend="jax",
+                                                  x0=tensor,
+                                                  args=[tensor.array,])
+
+
+@pytest.mark.parametrize("sparse_backend", sparse_backends + ["pytorch",])
+@pytest.mark.parametrize("dtype", np_float_dtypes)
 def test_eigsh_lanczos(sparse_backend, dtype):
   """
   Compares linalg.krylov.eigsh_lanczos with backend.eigsh_lanczos.
   """
-  shape = (4, 4)
+  n = 2
+  shape = (n, n)
   dtype = np_dtype_to_backend(sparse_backend, dtype)
-  tensor = tensornetwork.linalg.initialization.ones(shape,
-                                                    backend=sparse_backend,
-                                                    dtype=dtype)
-  x0 = tensornetwork.linalg.initialization.ones(shape, backend=sparse_backend,
+  A = tensornetwork.linalg.initialization.ones(shape,
+                                               backend=sparse_backend,
+                                               dtype=dtype)
+  x0 = tensornetwork.linalg.initialization.ones((n, 1), backend=sparse_backend,
                                                 dtype=dtype)
 
   def matvec(B):
-    return tensor @ B
-  result = tensornetwork.linalg.krylov.eigsh_lanczos(matvec,
-                                                     backend=tensor.backend,
-                                                     initial_state=x0)
+    return A @ B
+  result = tensornetwork.linalg.krylov.eigsh_lanczos(matvec, backend=A.backend,
+                                                     x0=x0, num_krylov_vecs=n-1)
   def array_matvec(B):
-    return tensor.array @ B
+    return A.array @ B
   rev, reV = result
-  test_result = tensor.backend.eigsh_lanczos(array_matvec,
-                                             initial_state=x0.array)
+  test_result = A.backend.eigsh_lanczos(array_matvec, initial_state=x0.array,
+                                        num_krylov_vecs=n-1)
   tev, teV = test_result
-
+  assert np.all(np.isfinite(np.ravel(np.array(rev))))
   np.testing.assert_allclose(np.array(rev), np.array(tev))
 
   for r, t in zip(reV, teV):
+    assert np.all(np.isfinite(np.ravel(r.array)))
     np.testing.assert_allclose(r.array, t)
 
 
@@ -159,36 +214,64 @@ def test_eigsh_lanczos(sparse_backend, dtype):
 @pytest.mark.parametrize("dtype", np_float_dtypes)
 def test_eigsh_lanczos_with_args(sparse_backend, dtype):
   """
-  Compares linalg.krylov.eigsh_lanczos with itself with extra arguments
-  supplied or not.
+  Compares linalg.krylov.eigsh_lanczos with backend.eigsh_lanczos.
   """
-  shape = (4, 4)
+  n = 2
+  shape = (n, n)
   dtype = np_dtype_to_backend(sparse_backend, dtype)
-  tensor = tensornetwork.linalg.initialization.ones(shape,
-                                                    backend=sparse_backend,
-                                                    dtype=dtype)
-  def matvec(B, A):
-    return A @ B
-
-  def matvec_noargs(B):
-    return tensor @ B
-
-  x0 = tensornetwork.linalg.initialization.ones(shape, backend=sparse_backend,
+  A = tensornetwork.linalg.initialization.ones(shape,
+                                               backend=sparse_backend,
+                                               dtype=dtype)
+  x0 = tensornetwork.linalg.initialization.ones((n, 1), backend=sparse_backend,
                                                 dtype=dtype)
 
-  result = tensornetwork.linalg.krylov.eigsh_lanczos(matvec,
-                                                     backend=tensor.backend,
-                                                     initial_state=x0,
-                                                     args=[tensor,])
+  def matvec(B):
+    return A @ B
+  def matvec_args(B, A):
+    return A @ B
 
-  test = tensornetwork.linalg.krylov.eigsh_lanczos(matvec_noargs,
-                                                   backend=tensor.backend,
-                                                   initial_state=x0)
+  result = tensornetwork.linalg.krylov.eigsh_lanczos(matvec, backend=A.backend,
+                                                     x0=x0, num_krylov_vecs=n-1)
+  test = tensornetwork.linalg.krylov.eigsh_lanczos(matvec_args,
+                                                   backend=A.backend,
+                                                   x0=x0, num_krylov_vecs=n-1,
+                                                   args=[A,])
   rev, reV = result
   tev, teV = test
+  assert np.all(np.isfinite(np.ravel(np.array(rev))))
   np.testing.assert_allclose(np.array(rev), np.array(tev))
+
   for r, t in zip(reV, teV):
-    np.testing.assert_allclose(r.array, t)
+    assert np.all(np.isfinite(np.ravel(r.array)))
+    np.testing.assert_allclose(r.array, t.array)
+
+
+def test_eigs_raises():
+  n = 2
+  shape = (n, n)
+  tensor = tensornetwork.linalg.initialization.ones(shape,
+                                                    backend="jax",
+                                                    dtype=np.float64)
+
+  def matvec(B):
+    return tensor @ B
+  with pytest.raises(ValueError):
+    _ = tensornetwork.linalg.krylov.eigs(matvec,
+                                         backend=None,
+                                         x0=None)
+  with pytest.raises(ValueError):
+    _ = tensornetwork.linalg.krylov.eigs(matvec,
+                                         backend="numpy",
+                                         x0=tensor)
+  with pytest.raises(TypeError):
+    _ = tensornetwork.linalg.krylov.eigs(matvec,
+                                         backend="numpy",
+                                         x0=tensor.array)
+  with pytest.raises(TypeError):
+    _ = tensornetwork.linalg.krylov.eigs(matvec,
+                                         backend="jax",
+                                         x0=tensor,
+                                         args=[tensor.array,])
 
 
 @pytest.mark.parametrize("sparse_backend", sparse_backends)
@@ -201,19 +284,77 @@ def test_eigs(sparse_backend, dtype):
   x0 = tensornetwork.linalg.initialization.ones(shape, backend=sparse_backend,
                                                 dtype=dtype)
   def matvec(B):
+    return tensor @ B
+
+  def test_matvec(B):
     return tensor.array @ B
 
   result = tensornetwork.linalg.krylov.eigs(matvec, backend=sparse_backend,
-                                            initial_state=x0)
+                                            x0=x0, num_krylov_vecs=3,
+                                            numeig=1)
   rev, reV = result
-  test_result = tensor.backend.eigs(matvec, initial_state=x0.array)
+  test_result = tensor.backend.eigs(test_matvec, initial_state=x0.array,
+                                    num_krylov_vecs=3, numeig=1)
   tev, _ = test_result
 
   for r, t, R in zip(rev, tev, reV):
     np.testing.assert_allclose(np.array(r), np.array(t))
-    testR = matvec(R.array) / r
-    np.testing.assert_allclose(testR, R.array, rtol=1E-5)
+    testR = matvec(R) / r
+    np.testing.assert_allclose(testR.array, R.array, rtol=1E-5)
 
+
+@pytest.mark.parametrize("sparse_backend", sparse_backends)
+@pytest.mark.parametrize("dtype", np_float_dtypes)
+def test_eigs_with_args(sparse_backend, dtype):
+  shape = (4, 4)
+  tensor = tensornetwork.linalg.initialization.ones(shape,
+                                                    backend=sparse_backend,
+                                                    dtype=dtype)
+  x0 = tensornetwork.linalg.initialization.ones(shape, backend=sparse_backend,
+                                                dtype=dtype)
+  def matvec(B):
+    return tensor @ B
+
+  def test_matvec(B, A):
+    return A @ B
+
+  result = tensornetwork.linalg.krylov.eigs(matvec, backend=sparse_backend,
+                                            x0=x0, num_krylov_vecs=3,
+                                            numeig=1)
+  rev, _ = result
+  test_result = tensornetwork.linalg.krylov.eigs(test_matvec, x0=x0,
+                                                 num_krylov_vecs=3, numeig=1,
+                                                 args=[tensor,])
+  tev, teV = test_result
+
+  for r, t, R in zip(rev, tev, teV):
+    np.testing.assert_allclose(np.array(r), np.array(t))
+    testR = matvec(R) / r
+    np.testing.assert_allclose(testR.array, R.array, rtol=1E-5)
+
+
+def test_gmres_raises():
+  n = 2
+  shape = (n, 1)
+  tensor = tensornetwork.linalg.initialization.ones(shape,
+                                                    backend="jax",
+                                                    dtype=np.float64)
+  tensornp = tensornetwork.linalg.initialization.ones(shape,
+                                                      backend="numpy",
+                                                      dtype=np.float64)
+  def matvec(B):
+    return tensor @ B
+  with pytest.raises(ValueError):
+    _ = tensornetwork.linalg.krylov.gmres(matvec, tensor, x0=tensornp)
+  with pytest.raises(ValueError):
+    _ = tensornetwork.linalg.krylov.gmres(matvec, tensornp, x0=tensor)
+  with pytest.raises(TypeError):
+    _ = tensornetwork.linalg.krylov.gmres(matvec, tensor.array)
+  with pytest.raises(TypeError):
+    _ = tensornetwork.linalg.krylov.gmres(matvec, tensor, x0=tensor.array)
+  with pytest.raises(TypeError):
+    _ = tensornetwork.linalg.krylov.gmres(matvec, tensor,
+                                          A_args=[tensor.array,])
 
 
 @pytest.mark.parametrize("sparse_backend", sparse_backends)
@@ -221,18 +362,43 @@ def test_eigs(sparse_backend, dtype):
 def test_gmres(dtype, sparse_backend):
   Adat = np.array(([[1, 1], [3, -4]]), dtype=dtype)
   A = tensornetwork.tensor.Tensor(Adat, backend=sparse_backend)
-  bdat = np.array([3, 2], dtype=dtype)
+  bdat = np.array([3, 2], dtype=dtype).reshape((2, 1))
   b = tensornetwork.tensor.Tensor(bdat, backend=sparse_backend)
-  x0dat = np.ones(2, dtype=dtype)
+  x0dat = np.ones((2, 1), dtype=dtype)
   x0 = tensornetwork.tensor.Tensor(x0dat, backend=sparse_backend)
   n_kry = 2
   def A_mv(y):
+    return A @ y
+  def A_mv_arr(y):
     return A.array @ y
 
-  x, _ = A.backend.gmres(A_mv, bdat, x0=x0dat, num_krylov_vectors=n_kry)
+  x, _ = A.backend.gmres(A_mv_arr, bdat, x0=x0dat, num_krylov_vectors=n_kry)
   xT, _ = tensornetwork.linalg.krylov.gmres(A_mv, b, x0=x0,
                                             num_krylov_vectors=n_kry)
   np.testing.assert_allclose(x, xT.array)
+
+
+@pytest.mark.parametrize("sparse_backend", sparse_backends)
+@pytest.mark.parametrize("dtype", np_float_dtypes)
+def test_gmres_with_args(dtype, sparse_backend):
+  Adat = np.array(([[1, 1], [3, -4]]), dtype=dtype)
+  A = tensornetwork.tensor.Tensor(Adat, backend=sparse_backend)
+  bdat = np.array([3, 2], dtype=dtype).reshape((2, 1))
+  b = tensornetwork.tensor.Tensor(bdat, backend=sparse_backend)
+  x0dat = np.ones((2, 1), dtype=dtype)
+  x0 = tensornetwork.tensor.Tensor(x0dat, backend=sparse_backend)
+  n_kry = 2
+  def A_mv(y):
+    return A @ y
+  def A_mv_test(y, A):
+    return A @ y
+
+  x, _ = tensornetwork.linalg.krylov.gmres(A_mv, b, x0=x0,
+                                           num_krylov_vectors=n_kry)
+  xT, _ = tensornetwork.linalg.krylov.gmres(A_mv_test, b, x0=x0,
+                                            num_krylov_vectors=n_kry,
+                                            A_args=[A,])
+  np.testing.assert_allclose(x.array, xT.array)
 
 
 @pytest.mark.parametrize("dtype", np_float_dtypes)


### PR DESCRIPTION
Changes the functions in tensornetwork/linalg/krylov.py so that the matvec functions can be written directly in terms of tn.Tensor without triggering spurious recompilations in Jax. Also adds more extensive testing and error checking.