### PR TITLE
Fix jax eigs bug

### DIFF
--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -237,7 +237,7 @@ class JaxBackend(abstract_backend.AbstractBackend):
            tol: float = 1E-8,
            which: Text = 'LR',
            maxiter: int = 20,
-           QR_thresh: float = 1E-12) -> Tuple[Tensor, List]:
+           res_thresh: float = 1E-12) -> Tuple[Tensor, List]:
     """
     Implicitly restarted Arnoldi method for finding the lowest
     eigenvector-eigenvalue pairs of a linear operator `A`.
@@ -297,6 +297,9 @@ class JaxBackend(abstract_backend.AbstractBackend):
         (larges magnitude).
       maxiter: Maximum number of restarts. For `maxiter=0` the routine becomes
         equivalent to a simple Arnoldi method.
+      QR_thresh: Threshold parameter. Implicitly restarted arnoldi terminates
+        if the norm of the residual `fk` of the shifted arnoldi factorization 
+        falls below `res_thresh` (see
     Returns:
       (eigvals, eigvecs)
        eigvals: A list of `numeig` eigenvalues
@@ -328,7 +331,7 @@ class JaxBackend(abstract_backend.AbstractBackend):
     return _CACHED_FUNCTIONS["imp_arnoldi"](_CACHED_MATVECS[A], args,
                                             initial_state, num_krylov_vecs,
                                             numeig, which, tol, maxiter,
-                                            QR_thresh)
+                                            res_thresh)
 
   def eigsh_lanczos(
       self,

--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -236,7 +236,7 @@ class JaxBackend(abstract_backend.AbstractBackend):
            numeig: int = 6,
            tol: float = 1E-8,
            which: Text = 'LR',
-           maxiter: int = 20) -> Tuple[Tensor, List]:
+           maxiter: int = 20, QR_thresh: float=1E-12) -> Tuple[Tensor, List]:
     """
     Implicitly restarted Arnoldi method for finding the lowest
     eigenvector-eigenvalue pairs of a linear operator `A`.
@@ -326,7 +326,7 @@ class JaxBackend(abstract_backend.AbstractBackend):
       _CACHED_FUNCTIONS["imp_arnoldi"] = imp_arnoldi
     return _CACHED_FUNCTIONS["imp_arnoldi"](_CACHED_MATVECS[A], args,
                                             initial_state, num_krylov_vecs,
-                                            numeig, which, tol, maxiter)
+                                            numeig, which, tol, maxiter, QR_thresh)
 
   def eigsh_lanczos(
       self,

--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -226,7 +226,7 @@ class JaxBackend(abstract_backend.AbstractBackend):
     return libjax.random.uniform(
         key, shape, minval=boundaries[0], maxval=boundaries[1]).astype(dtype)
 
-  def eigs(self,
+  def eigs(self, #pylint: disable=arguments-differ
            A: Callable,
            args: Optional[List] = None,
            initial_state: Optional[Tensor] = None,
@@ -236,7 +236,8 @@ class JaxBackend(abstract_backend.AbstractBackend):
            numeig: int = 6,
            tol: float = 1E-8,
            which: Text = 'LR',
-           maxiter: int = 20, QR_thresh: float=1E-12) -> Tuple[Tensor, List]:
+           maxiter: int = 20,
+           QR_thresh: float = 1E-12) -> Tuple[Tensor, List]:
     """
     Implicitly restarted Arnoldi method for finding the lowest
     eigenvector-eigenvalue pairs of a linear operator `A`.
@@ -326,7 +327,8 @@ class JaxBackend(abstract_backend.AbstractBackend):
       _CACHED_FUNCTIONS["imp_arnoldi"] = imp_arnoldi
     return _CACHED_FUNCTIONS["imp_arnoldi"](_CACHED_MATVECS[A], args,
                                             initial_state, num_krylov_vecs,
-                                            numeig, which, tol, maxiter, QR_thresh)
+                                            numeig, which, tol, maxiter,
+                                            QR_thresh)
 
   def eigsh_lanczos(
       self,

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -710,7 +710,12 @@ def test_matmul():
   actual = backend.matmul(a, b)
   expected = np.matmul(t1, t2)
   np.testing.assert_allclose(expected, actual)
-
+  t3 = np.random.rand(10)
+  t4 = np.random.rand(11)
+  c = backend.convert_to_tensor(t3)
+  d = backend.convert_to_tensor(t4)
+  with pytest.raises(ValueError, match="inputs to"):
+    backend.matmul(c, d)
 
 def test_gmres_raises():
   backend = jax_backend.JaxBackend()

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -649,7 +649,7 @@ def test_eigs_raises():
         f" is currently not supported."):
       backend.eigs(lambda x: x, which=which)
   with pytest.raises(KeyError, match="dtype"):
-    backend.eigs(lambda x: x, shape = (10,), dtype=np.int32)    
+    backend.eigs(lambda x: x, shape = (10,), dtype=np.int32)
 
 ##################################################################
 #############  This test should just not crash    ################
@@ -907,3 +907,16 @@ def test_pivot(dtype, pivot_axis):
   expected = tensor.reshape(pivot_shape)
   actual = backend.pivot(tensor, pivot_axis=pivot_axis)
   np.testing.assert_allclose(expected, actual)
+
+
+@pytest.mark.parametrize("dtype, atol", [(np.float32, 1E-6),
+                                         (np.float64, 1E-10),
+                                         (np.complex64, 1E-6),
+                                         (np.complex128, 1E-10)])
+def test_inv(dtype, atol):
+  shape = (10, 10)
+  backend = jax_backend.JaxBackend()
+  matrix = backend.randn(shape, dtype=dtype, seed=10)
+  inv = backend.inv(matrix)
+  np.testing.assert_allclose(inv @ matrix, np.eye(10), atol=atol)
+  np.testing.assert_allclose(matrix @ inv, np.eye(10), atol=atol)

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -103,7 +103,6 @@ def test_convert_to_tensor():
   assert isinstance(actual, type(expected))
   np.testing.assert_allclose(expected, actual)
 
-
 def test_outer_product():
   backend = jax_backend.JaxBackend()
   a = backend.convert_to_tensor(2 * np.ones((2, 1)))
@@ -123,10 +122,9 @@ def test_einsum():
   np.testing.assert_allclose(expected, actual)
 
 
-@pytest.mark.skip(reason="TODO(chaseriley): Add type checking.")
 def test_convert_bad_test():
   backend = jax_backend.JaxBackend()
-  with pytest.raises(TypeError):
+  with pytest.raises(TypeError, match="Expected"):
     backend.convert_to_tensor(tf.ones((2, 2)))
 
 

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -662,7 +662,7 @@ def test_eigs_raises():
         f" is currently not supported."):
       backend.eigs(lambda x: x, which=which)
   with pytest.raises(KeyError, match="dtype"):
-    backend.eigs(lambda x: x, shape = (10,), dtype=np.int32)
+    backend.eigs(lambda x: x, shape=(10,), dtype=np.int32)
 
 ##################################################################
 #############  This test should just not crash    ################

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -653,13 +653,13 @@ def test_eigs_raises():
 ##################################################################
 #############  This test should just not crash    ################
 ##################################################################
-@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+@pytest.mark.parametrize("dtype",
+                         [np.float64, np.complex128, np.float32, np.complex64])
 def test_eigs_bugfix(dtype):
   backend = jax_backend.JaxBackend()
   D = 200
-  dtype = np.complex128
-  mat = np.random.rand(D, D).astype(dtype)
-  x = np.random.rand(D).astype(dtype)
+  mat = jax.numpy.array(np.random.rand(D, D).astype(dtype))
+  x = jax.numpy.array(np.random.rand(D).astype(dtype))
 
   def matvec_jax(vector, matrix):
     return matrix @ vector
@@ -672,6 +672,7 @@ def test_eigs_bugfix(dtype):
       maxiter=10,
       num_krylov_vecs=100,
       tol=0.0001)
+  #this test will cause some annoying output to std buffer
   with pytest.raises(np.linalg.LinAlgError):
     backend.eigs(
         matvec_jax, [mat],
@@ -681,7 +682,7 @@ def test_eigs_bugfix(dtype):
         maxiter=10,
         num_krylov_vecs=100,
         tol=0.0001,
-        QR_thresh=0.0)
+        res_thresh=0.0)
 
 
 def test_sum():

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -550,7 +550,8 @@ def compare_eigvals_and_eigvecs(U, eta, U_exact, eta_exact, thresh=1E-8):
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
-def test_eigs_all_eigvals_with_init(dtype):
+@pytest.mark.parametrize("which", ["LR", "LM"])
+def test_eigs_all_eigvals_with_init(dtype, which):
   backend = jax_backend.JaxBackend()
   D = 16
   np.random.seed(10)
@@ -560,14 +561,15 @@ def test_eigs_all_eigvals_with_init(dtype):
   def mv(x, H):
     return jax.numpy.dot(H, x)
 
-  eta, U = backend.eigs(mv, [H], init, numeig=D, num_krylov_vecs=D)
+  eta, U = backend.eigs(mv, [H], init, numeig=D, num_krylov_vecs=D, which=which)
   eta_exact, U_exact = np.linalg.eig(H)
   compare_eigvals_and_eigvecs(
       np.stack(U, axis=1), eta, U_exact, eta_exact, thresh=1E-8)
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
-def test_eigs_all_eigvals_no_init(dtype):
+@pytest.mark.parametrize("which", ["LR", "LM"])
+def test_eigs_all_eigvals_no_init(dtype, which):
   backend = jax_backend.JaxBackend()
   D = 16
   np.random.seed(10)
@@ -577,14 +579,20 @@ def test_eigs_all_eigvals_no_init(dtype):
     return jax.numpy.dot(H, x)
 
   eta, U = backend.eigs(
-      mv, [H], shape=(D,), dtype=dtype, numeig=D, num_krylov_vecs=D)
+      mv, [H],
+      shape=(D,),
+      dtype=dtype,
+      numeig=D,
+      num_krylov_vecs=D,
+      which=which)
   eta_exact, U_exact = np.linalg.eig(H)
   compare_eigvals_and_eigvecs(
       np.stack(U, axis=1), eta, U_exact, eta_exact, thresh=1E-8)
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
-def test_eigs_few_eigvals_with_init(dtype):
+@pytest.mark.parametrize("which", ["LR", "LM"])
+def test_eigs_few_eigvals_with_init(dtype, which):
   backend = jax_backend.JaxBackend()
   D = 16
   np.random.seed(10)
@@ -594,14 +602,16 @@ def test_eigs_few_eigvals_with_init(dtype):
   def mv(x, H):
     return jax.numpy.dot(H, x)
 
-  eta, U = backend.eigs(mv, [H], init, numeig=4, num_krylov_vecs=10, maxiter=50)
+  eta, U = backend.eigs(
+      mv, [H], init, numeig=4, num_krylov_vecs=16, maxiter=50, which=which)
   eta_exact, U_exact = np.linalg.eig(H)
   compare_eigvals_and_eigvecs(
       np.stack(U, axis=1), eta, U_exact, eta_exact, thresh=1E-8)
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
-def test_eigs_few_eigvals_no_init(dtype):
+@pytest.mark.parametrize("which", ["LR", "LM"])
+def test_eigs_few_eigvals_no_init(dtype, which):
   backend = jax_backend.JaxBackend()
   D = 16
   np.random.seed(10)
@@ -611,7 +621,12 @@ def test_eigs_few_eigvals_no_init(dtype):
     return jax.numpy.dot(H, x)
 
   eta, U = backend.eigs(
-      mv, [H], shape=(D,), dtype=dtype, numeig=4, num_krylov_vecs=10)
+      mv, [H],
+      shape=(D,),
+      dtype=dtype,
+      numeig=4,
+      num_krylov_vecs=16,
+      which=which)
   eta_exact, U_exact = np.linalg.eig(H)
   compare_eigvals_and_eigvecs(
       np.stack(U, axis=1), eta, U_exact, eta_exact, thresh=1E-8)
@@ -923,9 +938,6 @@ def test_inv(dtype, atol):
   inv = backend.inv(matrix)
   np.testing.assert_allclose(inv @ matrix, np.eye(10), atol=atol)
   np.testing.assert_allclose(matrix @ inv, np.eye(10), atol=atol)
-  tensor = backend.randn((10, 10, 10), dtype=dtype, seed=10)  
+  tensor = backend.randn((10, 10, 10), dtype=dtype, seed=10)
   with pytest.raises(ValueError, match="input to"):
     backend.inv(tensor)
-  
-
-  

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -648,7 +648,8 @@ def test_eigs_raises():
         ValueError, match=f"which = {which}"
         f" is currently not supported."):
       backend.eigs(lambda x: x, which=which)
-
+  with pytest.raises(KeyError, match="dtype"):
+    backend.eigs(lambda x: x, shape = (10,), dtype=np.int32)    
 
 ##################################################################
 #############  This test should just not crash    ################

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -650,6 +650,40 @@ def test_eigs_raises():
       backend.eigs(lambda x: x, which=which)
 
 
+##################################################################
+#############  This test should just not crash    ################
+##################################################################
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+def test_eigs_bugfix(dtype):
+  backend = jax_backend.JaxBackend()
+  D = 200
+  dtype = np.complex128
+  mat = np.random.rand(D, D).astype(dtype)
+  x = np.random.rand(D).astype(dtype)
+
+  def matvec_jax(vector, matrix):
+    return matrix @ vector
+
+  backend.eigs(
+      matvec_jax, [mat],
+      numeig=1,
+      initial_state=x,
+      which='LR',
+      maxiter=10,
+      num_krylov_vecs=100,
+      tol=0.0001)
+  with pytest.raises(np.linalg.LinAlgError):
+    backend.eigs(
+        matvec_jax, [mat],
+        numeig=1,
+        initial_state=x,
+        which='LR',
+        maxiter=10,
+        num_krylov_vecs=100,
+        tol=0.0001,
+        QR_thresh=0.0)
+
+
 def test_sum():
   np.random.seed(10)
   backend = jax_backend.JaxBackend()

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -920,3 +920,9 @@ def test_inv(dtype, atol):
   inv = backend.inv(matrix)
   np.testing.assert_allclose(inv @ matrix, np.eye(10), atol=atol)
   np.testing.assert_allclose(matrix @ inv, np.eye(10), atol=atol)
+  tensor = backend.randn((10, 10, 10), dtype=dtype, seed=10)  
+  with pytest.raises(ValueError, match="input to"):
+    backend.inv(tensor)
+  
+
+  

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -632,6 +632,25 @@ def test_eigs_few_eigvals_no_init(dtype, which):
       np.stack(U, axis=1), eta, U_exact, eta_exact, thresh=1E-8)
 
 
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+@pytest.mark.parametrize("which", ["LR", "LM"])
+def test_eigs_large_ncv_with_init(dtype, which):
+  backend = jax_backend.JaxBackend()
+  D = 16
+  np.random.seed(10)
+  init = backend.randn((D,), dtype=dtype, seed=10)
+  H = backend.randn((D, D), dtype=dtype, seed=10)
+
+  def mv(x, H):
+    return jax.numpy.dot(H, x)
+
+  eta, U = backend.eigs(
+      mv, [H], init, numeig=4, num_krylov_vecs=50, maxiter=50, which=which)
+  eta_exact, U_exact = np.linalg.eig(H)
+  compare_eigvals_and_eigvecs(
+      np.stack(U, axis=1), eta, U_exact, eta_exact, thresh=1E-8)
+
+  
 def test_eigs_raises():
   backend = jax_backend.JaxBackend()
   with pytest.raises(

--- a/tensornetwork/backends/jax/jitted_functions.py
+++ b/tensornetwork/backends/jax/jitted_functions.py
@@ -465,8 +465,6 @@ def _implicitly_restarted_arnoldi(jax):
         (num_krylov_vecs + 1, jax.numpy.ravel(initial_state).shape[0]),
         dtype=dtype)
     H = jax.numpy.zeros((num_krylov_vecs + 1, num_krylov_vecs), dtype=dtype)
-    norms = jax.numpy.zeros(num_krylov_vecs, dtype=np.float64)
-    norms_before = jax.numpy.zeros(num_krylov_vecs, dtype=np.float64)
     # perform initial arnoldi factorization
     Vm_tmp, Hm_tmp, numits, converged = arnoldi_fact(matvec, args,
                                                      initial_state,
@@ -511,8 +509,8 @@ def _implicitly_restarted_arnoldi(jax):
 
       # restart
       Vm_tmp, Hm_tmp, _, converged = arnoldi_fact(matvec, args, v0,
-                                                     krylov_vectors, H, numeig,
-                                                     num_krylov_vecs, eps)
+                                                  krylov_vectors, H, numeig,
+                                                  num_krylov_vecs, eps)
       Vm, Hm, fm = update_data(Vm_tmp, Hm_tmp, num_krylov_vecs)
       it += 1
 

--- a/tensornetwork/backends/jax/jitted_functions.py
+++ b/tensornetwork/backends/jax/jitted_functions.py
@@ -471,7 +471,7 @@ def _implicitly_restarted_arnoldi(jax):
                                                      num_krylov_vecs, eps)
     # obtain an m-step arnoldi factorization
     Vm, Hm, fm = update_data(Vm_tmp, Hm_tmp, numits)
-
+    
     it = 0
     if which == 'LR':
       _which = 0
@@ -494,7 +494,7 @@ def _implicitly_restarted_arnoldi(jax):
       Vm = Vm.astype(dtype)
       Hm = Hm.astype(dtype)
       fm = fm.astype(dtype)
-    converged = False
+      
     while (it < maxiter) and (not converged):
       evals, _ = jax.numpy.linalg.eig(Hm)
       krylov_vectors, H, fk, converged = shifted_QR(Vm, Hm, fm, evals, numeig,

--- a/tensornetwork/backends/jax/jitted_functions.py
+++ b/tensornetwork/backends/jax/jitted_functions.py
@@ -289,7 +289,7 @@ def _generate_arnoldi_factorization(jax):
 
     def cond_fun(vals):
       # Continue loop while iteration < num_krylov_vecs and norm > eps
-      _, _, _, _, norm, _, iteration, _= vals
+      _, _, _, _, norm, _, iteration, _ = vals
       counter_done = (iteration >= num_krylov_vecs)
       norm_not_too_small = norm > eps
       continue_iteration = jax.lax.cond(counter_done,
@@ -504,9 +504,6 @@ def _implicitly_restarted_arnoldi(jax):
         converged = True
         break
       v0 = jax.numpy.reshape(fk, initial_state.shape)
-      norms = jax.numpy.zeros(num_krylov_vecs, dtype=np.float64)
-      norms_before = jax.numpy.zeros(num_krylov_vecs, dtype=np.float64)
-
       # restart
       Vm_tmp, Hm_tmp, _, converged = arnoldi_fact(matvec, args, v0,
                                                   krylov_vectors, H, numeig,

--- a/tensornetwork/backends/jax/jitted_functions.py
+++ b/tensornetwork/backends/jax/jitted_functions.py
@@ -393,7 +393,8 @@ def _implicitly_restarted_arnoldi(jax):
     Z = jax.numpy.linalg.norm(fk)
     #if fk is a zero-vector then arnoldi has exactly converged.
     #use small threshold to check this
-    converged = jax.lax.cond(Z < res_thresh, lambda x: True, lambda x: False, None)
+    converged = jax.lax.cond(Z < res_thresh, lambda x: True, lambda x: False,
+                             None)
     return krylov_vectors, H, fk, converged
 
   @partial(jax.jit, static_argnums=(2,))


### PR DESCRIPTION
This PR fixes a bug that causes `JaxBackend.eigs` to return `NaN` values for certain operators and arguments.