### PR TITLE
Tensor to master

### DIFF
--- a/tensornetwork/__init__.py
+++ b/tensornetwork/__init__.py
@@ -6,6 +6,8 @@ from tensornetwork.network_operations import (
     reduced_density, remove_node, replicate_nodes, split_node,
     split_node_full_svd, split_node_qr, split_node_rq, switch_backend)
 
+from tensornetwork.tensor import Tensor
+
 #pylint: disable=line-too-long
 from tensornetwork.linalg.linalg import (
     conj,

--- a/tensornetwork/backends/abstract_backend.py
+++ b/tensornetwork/backends/abstract_backend.py
@@ -50,8 +50,10 @@ class AbstractBackend:
     raise NotImplementedError(
         "Backend '{}' has not implemented reshape.".format(self.name))
 
-  def transpose(self, tensor: Tensor, perm: Sequence[int]) -> Tensor:
-    """Transpose a tensor according to a given permutation
+  def transpose(self, tensor: Tensor,
+                perm: Optional[Sequence[int]] = None) -> Tensor:
+    """Transpose a tensor according to a given permutation. By default
+    the axes are reversed.
     Args:
       tensor: A tensor.
       perm: The permutation of the axes.

--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -55,7 +55,7 @@ class JaxBackend(abstract_backend.AbstractBackend):
   def reshape(self, tensor: Tensor, shape: Tensor) -> Tensor:
     return jnp.reshape(tensor, np.asarray(shape).astype(np.int32))
 
-  def transpose(self, tensor, perm) -> Tensor:
+  def transpose(self, tensor, perm=None) -> Tensor:
     return jnp.transpose(tensor, perm)
 
   def shape_concat(self, values: Tensor, axis: int) -> Tensor:

--- a/tensornetwork/backends/jax/jax_backend_test.py
+++ b/tensornetwork/backends/jax/jax_backend_test.py
@@ -38,6 +38,16 @@ def test_transpose():
   np.testing.assert_allclose(expected, actual)
 
 
+def test_transpose_noperm():
+  backend = jax_backend.JaxBackend()
+  a = backend.convert_to_tensor(
+      np.array([[[1., 2.], [3., 4.]], [[5., 6.], [7., 8.]]]))
+  actual = backend.transpose(a) # [2, 1, 0]
+  actual = backend.transpose(actual, perm=[0, 2, 1])
+  expected = np.array([[[1.0, 3.0], [5.0, 7.0]], [[2.0, 4.0], [6.0, 8.0]]])
+  np.testing.assert_allclose(expected, actual)
+
+
 def test_shape_concat():
   backend = jax_backend.JaxBackend()
   a = backend.convert_to_tensor(2 * np.ones((1, 3, 1)))

--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -50,7 +50,8 @@ class NumPyBackend(abstract_backend.AbstractBackend):
   def reshape(self, tensor: Tensor, shape: Tensor) -> Tensor:
     return np.reshape(tensor, np.asarray(shape).astype(np.int32))
 
-  def transpose(self, tensor, perm) -> Tensor:
+  def transpose(self, tensor: Tensor,
+                perm: Optional[Sequence] = None) -> Tensor:
     return np.transpose(tensor, perm)
 
   def slice(self, tensor: Tensor, start_indices: Tuple[int, ...],

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -34,6 +34,16 @@ def test_transpose():
   np.testing.assert_allclose(expected, actual)
 
 
+def test_transpose_noperm():
+  backend = numpy_backend.NumPyBackend()
+  a = backend.convert_to_tensor(
+      np.array([[[1., 2.], [3., 4.]], [[5., 6.], [7., 8.]]]))
+  actual = backend.transpose(a) # [2, 1, 0]
+  actual = backend.transpose(actual, perm=[0, 2, 1])
+  expected = np.array([[[1.0, 3.0], [5.0, 7.0]], [[2.0, 4.0], [6.0, 8.0]]])
+  np.testing.assert_allclose(expected, actual)
+
+
 def test_shape_concat():
   backend = numpy_backend.NumPyBackend()
   a = backend.convert_to_tensor(2 * np.ones((1, 3, 1)))

--- a/tensornetwork/backends/pytorch/pytorch_backend.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend.py
@@ -47,7 +47,9 @@ class PyTorchBackend(abstract_backend.AbstractBackend):
   def reshape(self, tensor: Tensor, shape: Tensor) -> Tensor:
     return torchlib.reshape(tensor, tuple(np.array(shape).astype(int)))
 
-  def transpose(self, tensor, perm) -> Tensor:
+  def transpose(self, tensor, perm=None) -> Tensor:
+    if perm is None:
+      perm = tuple(range(tensor.ndim - 1, -1, -1))
     return tensor.permute(perm)
 
   def slice(self, tensor: Tensor, start_indices: Tuple[int, ...],

--- a/tensornetwork/backends/pytorch/pytorch_backend_test.py
+++ b/tensornetwork/backends/pytorch/pytorch_backend_test.py
@@ -34,6 +34,16 @@ def test_transpose():
   np.testing.assert_allclose(expected, actual)
 
 
+def test_transpose_noperm():
+  backend = pytorch_backend.PyTorchBackend()
+  a = backend.convert_to_tensor(
+      np.array([[[1., 2.], [3., 4.]], [[5., 6.], [7., 8.]]]))
+  actual = backend.transpose(a) # [2, 1, 0]
+  actual = backend.transpose(actual, perm=[0, 2, 1])
+  expected = np.array([[[1.0, 3.0], [5.0, 7.0]], [[2.0, 4.0], [6.0, 8.0]]])
+  np.testing.assert_allclose(expected, actual)
+
+
 def test_shape_concat():
   backend = pytorch_backend.PyTorchBackend()
   a = backend.convert_to_tensor(2 * np.ones((1, 3, 1)))

--- a/tensornetwork/backends/symmetric/symmetric_backend.py
+++ b/tensornetwork/backends/symmetric/symmetric_backend.py
@@ -42,7 +42,9 @@ class SymmetricBackend(abstract_backend.AbstractBackend):
   def reshape(self, tensor: Tensor, shape: Tensor) -> Tensor:
     return self.bs.reshape(tensor, numpy.asarray(shape).astype(numpy.int32))
 
-  def transpose(self, tensor, perm) -> Tensor:
+  def transpose(self, tensor, perm=None) -> Tensor:
+    if perm is None:
+      perm = tuple(range(tensor.ndim - 1, -1, -1))
     return self.bs.transpose(tensor, perm)
 
   def svd(

--- a/tensornetwork/backends/symmetric/symmetric_backend_test.py
+++ b/tensornetwork/backends/symmetric/symmetric_backend_test.py
@@ -177,6 +177,24 @@ def test_transpose(R, dtype, num_charges):
   ])
 
 
+@pytest.mark.parametrize("dtype", np_tensordot_dtypes)
+@pytest.mark.parametrize("R", [2, 3, 4, 5, 6, 7])
+@pytest.mark.parametrize("num_charges", [1, 2])
+def test_transpose_default(R, dtype, num_charges):
+  np.random.seed(10)
+  backend = symmetric_backend.SymmetricBackend()
+  a = get_tensor(R, num_charges, dtype)
+  order = np.arange(R)[::-1]
+  np.random.shuffle(order)
+  actual = backend.transpose(a)
+  expected = transpose(a, order)
+  np.testing.assert_allclose(expected.data, actual.data)
+  assert np.all([
+      charge_equal(expected._charges[n], actual._charges[n])
+      for n in range(len(actual._charges))
+  ])
+
+
 def test_shape_concat():
   backend = symmetric_backend.SymmetricBackend()
   a = np.asarray((2 * np.ones((1, 3, 1))))

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -48,7 +48,7 @@ class TensorFlowBackend(abstract_backend.AbstractBackend):
   def reshape(self, tensor: Tensor, shape: Tensor) -> Tensor:
     return tf.reshape(tensor, shape)
 
-  def transpose(self, tensor, perm) -> Tensor:
+  def transpose(self, tensor, perm=None) -> Tensor:
     return tf.transpose(tensor, perm)
 
   def slice(self, tensor: Tensor, start_indices: Tuple[int, ...],

--- a/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend_test.py
@@ -32,6 +32,16 @@ def test_transpose():
   np.testing.assert_allclose(expected, actual)
 
 
+def test_transpose_noperm():
+  backend = tensorflow_backend.TensorFlowBackend()
+  a = backend.convert_to_tensor(
+      np.array([[[1., 2.], [3., 4.]], [[5., 6.], [7., 8.]]]))
+  actual = backend.transpose(a) # [2, 1, 0]
+  actual = backend.transpose(actual, perm=[0, 2, 1])
+  expected = np.array([[[1.0, 3.0], [5.0, 7.0]], [[2.0, 4.0], [6.0, 8.0]]])
+  np.testing.assert_allclose(expected, actual)
+
+
 def test_shape_concat():
   backend = tensorflow_backend.TensorFlowBackend()
   a = backend.convert_to_tensor(2 * np.ones((1, 3, 1)))

--- a/tensornetwork/tensor.py
+++ b/tensornetwork/tensor.py
@@ -1,0 +1,201 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import copy
+import warnings
+from typing import Any, Union, Text, Optional, List, Sequence
+import numpy as np
+from tensornetwork.backends import abstract_backend
+from tensornetwork import backends, backend_contextmanager
+
+BaseBackend = abstract_backend.AbstractBackend
+
+class Tensor():
+  def __init__(self,
+               array: Any,
+               backend: Optional[Union[Text, BaseBackend]] = None) -> None:
+    if backend is None:
+      backend = backend_contextmanager.get_default_backend()
+    backend_obj = backends.backend_factory.get_backend(backend)
+    self.backend = backend_obj
+    self.array = self.backend.convert_to_tensor(array)
+    self.shape = array.shape
+    self.size = np.prod(self.shape)
+    self.ndim = len(self.shape)
+
+  @property
+  def dtype(self) -> Any: # To maintain backend independence
+    """ Returns: The dtype of the backend array.
+    """
+    return self.array.dtype
+
+  @property
+  def T(self) -> "Tensor":
+    """ The `Tensor` with reversed axes.
+    Returns:
+      The transposed `Tensor`.
+    """
+    return self.transpose()
+
+  @property
+  def H(self) -> "Tensor":
+    """ The conjugate `Tensor` with reversed axes.
+    """
+    star = self.backend.conj(self.array)
+    array_H = self.backend.transpose(star)
+    return Tensor(array_H, backend=self.backend)
+
+  def conj(self) -> "Tensor":
+    """ Returns: The complex-conjugated `Tensor`.
+    """
+    star = self.backend.conj(self.array)
+    return Tensor(star, backend=self.backend)
+
+  def conjugate(self) -> "Tensor":
+    """ Returns: The complex-conjugated `Tensor`.
+    """
+    return self.conj()
+
+  def copy(self) -> "Tensor":
+    """ Returns: A copy of the `Tensor`.
+    """
+    return copy.deepcopy(self)
+
+  def flatten(self):
+    """Return a new `Tensor` with the same number of elements but only one
+    dimension. This function differs from ravel in some cases at the backend
+    level. Notably, with the numpy backend, flatten always returns a copy,
+    wheras ravel returns a view when possible.
+    """
+    size = self.size
+    flat = self.reshape([size,]).copy()
+    return flat
+
+  def fill(self, val: float):
+    """ Returns a `Tensor` filled with the scalar value `val`.
+    Args:
+      val: The scalar value.
+    Returns:
+      filled: A `Tensor` of the same shape as this one whose entries are all
+              `val`.
+    """
+    vals = np.zeros(self.shape)
+    vals = val
+    mask = np.ones(self.shape)
+    filled_arr = self.backend.index_update(self.array, mask, vals)
+    return Tensor(filled_arr, backend=self.backend)
+
+  def hconj(self, perm: Optional[Sequence[int]] = None) -> "Tensor":
+    """ The Hermitian conjugated tensor; e.g. the complex conjugate tranposed
+    by the permutation set be `axes`. By default the axes are reversed.
+    Args:
+      perm: The permutation. If None (default) the index order is reversed.  
+    Returns:
+      The Hermitian conjugated `Tensor`.
+    """
+    dag = self.conj().transpose(perm=perm)
+    return dag
+
+  def ravel(self):
+    """Return a new `Tensor` with the same number of elements but only one
+    dimension.
+    """
+    size = self.size
+    flat = self.reshape(shape=[size,])
+    return flat
+
+  def reshape(self, shape: Sequence[int]) -> "Tensor":
+    """Return a new `Tensor` with the same data but a new shape `shape`.
+    Args:
+      shape: The new shape.
+    Returns:
+      The reshaped `Tensor`.
+    """
+    reshaped = self.backend.reshape(self.array, shape)
+    return Tensor(reshaped, backend=self.backend)
+
+  def squeeze(self):
+    """Return a new `Tensor` with all axes of size 1 eliminated.
+    """
+    shape = self.shape
+    squeezed_shape = [d for d in shape if d != 1]
+    return self.reshape(squeezed_shape)
+
+  def transpose(self, perm: Optional[Sequence[int]] = None) -> "Tensor":
+    """ Return a new `Tensor` transposed according to the permutation set
+    by `axes`. By default the axes are reversed.
+    Args:
+      axes: The permutation. If None (default) the index order is reversed.
+    Returns:
+      The transposed `Tensor`.
+    """
+    array_T = self.backend.transpose(self.array, perm=perm)
+    return Tensor(array_T, backend=self.backend)
+
+  def __mul__(self, other: Union["Tensor", float]) -> "Tensor":
+    if isinstance(other, Tensor):
+      if self.backend.name != other.backend.name:
+        errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
+                  f"not agree.")
+        raise ValueError(errstr)
+      other = other.array
+    array = self.backend.multiply(self.array, other)
+    return Tensor(array, backend=self.backend)
+
+  __rmul__ = __mul__
+
+  def __truediv__(self, other: Union["Tensor", float]) -> "Tensor":
+    if isinstance(other, Tensor):
+      if self.backend.name != other.backend.name:
+        errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
+                  f"not agree.")
+        raise ValueError(errstr)
+      other = other.array
+    array = self.backend.divide(self.array, other)
+    return Tensor(array, backend=self.backend)
+
+  def __sub__(self, other: Union["Tensor", float]) -> "Tensor":
+    if isinstance(other, Tensor):
+      if self.backend.name != other.backend.name:
+        errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
+                  f"not agree.")
+        raise ValueError(errstr)
+      other = other.array
+    array = self.backend.subtraction(self.array, other)
+    return Tensor(array, backend=self.backend)
+
+  def __rsub__(self, other: float) -> "Tensor":
+    array = self.backend.subtraction(other, self.array)
+    return Tensor(array, backend=self.backend)
+
+  def __add__(self, other: Union["Tensor", float]) -> "Tensor":
+    if isinstance(other, Tensor):
+      if self.backend.name != other.backend.name:
+        errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
+                  f"not agree.")
+        raise ValueError(errstr)
+      other = other.array
+    array = self.backend.addition(self.array, other)
+    return Tensor(array, backend=self.backend)
+
+  __radd__ = __add__
+
+  def __matmul__(self, other: "Tensor") -> "Tensor":
+    if self.backend.name != other.backend.name:
+      errstr = (f"Backends {self.backend.name} and {other.backend.name} did not"
+                f"agree.")
+      raise ValueError(errstr)
+    array = self.backend.matmul(self.array, other.array)
+    return Tensor(array, backend=self.backend)

--- a/tensornetwork/tensor.py
+++ b/tensornetwork/tensor.py
@@ -147,8 +147,8 @@ class Tensor():
   def __mul__(self, other: Union["Tensor", float]) -> "Tensor":
     if isinstance(other, Tensor):
       if self.backend.name != other.backend.name:
-        errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
-                  f"not agree.")
+        errstr = (f"Given backens are inconsistent. Found '{self.backend.name}'"
+                  f"and '{other.backend.name}'")
         raise ValueError(errstr)
       other = other.array
     array = self.backend.multiply(self.array, other)
@@ -159,8 +159,8 @@ class Tensor():
   def __truediv__(self, other: Union["Tensor", float]) -> "Tensor":
     if isinstance(other, Tensor):
       if self.backend.name != other.backend.name:
-        errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
-                  f"not agree.")
+        errstr = (f"Given backens are inconsistent. Found '{self.backend.name}'"
+                  f"and '{other.backend.name}'")
         raise ValueError(errstr)
       other = other.array
     array = self.backend.divide(self.array, other)
@@ -169,8 +169,8 @@ class Tensor():
   def __sub__(self, other: Union["Tensor", float]) -> "Tensor":
     if isinstance(other, Tensor):
       if self.backend.name != other.backend.name:
-        errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
-                  f"not agree.")
+        errstr = (f"Given backens are inconsistent. Found '{self.backend.name}'"
+                  f"and '{other.backend.name}'")
         raise ValueError(errstr)
       other = other.array
     array = self.backend.subtraction(self.array, other)
@@ -183,8 +183,8 @@ class Tensor():
   def __add__(self, other: Union["Tensor", float]) -> "Tensor":
     if isinstance(other, Tensor):
       if self.backend.name != other.backend.name:
-        errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
-                  f"not agree.")
+        errstr = (f"Given backens are inconsistent. Found '{self.backend.name}'"
+                  f"and '{other.backend.name}'")
         raise ValueError(errstr)
       other = other.array
     array = self.backend.addition(self.array, other)
@@ -194,8 +194,8 @@ class Tensor():
 
   def __matmul__(self, other: "Tensor") -> "Tensor":
     if self.backend.name != other.backend.name:
-      errstr = (f"Backends {self.backend.name} and {other.backend.name} did not"
-                f"agree.")
+      errstr = (f"Backends {self.backend.name} and {other.backend.name} did"
+                f"not agree.")
       raise ValueError(errstr)
     array = self.backend.matmul(self.array, other.array)
     return Tensor(array, backend=self.backend)

--- a/tensornetwork/tensor.py
+++ b/tensornetwork/tensor.py
@@ -83,20 +83,6 @@ class Tensor():
     flat = self.reshape([size,]).copy()
     return flat
 
-  def fill(self, val: float):
-    """ Returns a `Tensor` filled with the scalar value `val`.
-    Args:
-      val: The scalar value.
-    Returns:
-      filled: A `Tensor` of the same shape as this one whose entries are all
-              `val`.
-    """
-    vals = np.zeros(self.shape)
-    vals = val
-    mask = np.ones(self.shape)
-    filled_arr = self.backend.index_update(self.array, mask, vals)
-    return Tensor(filled_arr, backend=self.backend)
-
   def hconj(self, perm: Optional[Sequence[int]] = None) -> "Tensor":
     """ The Hermitian conjugated tensor; e.g. the complex conjugate tranposed
     by the permutation set be `axes`. By default the axes are reversed.

--- a/tensornetwork/tests/tensor_test.py
+++ b/tensornetwork/tests/tensor_test.py
@@ -1,0 +1,383 @@
+# Copyright 2019 The TensorNetwork Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import config
+import tensorflow as tf
+import torch
+import pytest
+import tensornetwork
+from tensornetwork.backends import abstract_backend
+from tensornetwork import backends, backend_contextmanager
+from tensornetwork.tests import testing_utils
+
+#pylint: disable=no-member
+config.update("jax_enable_x64", True)
+BaseBackend = abstract_backend.AbstractBackend
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_init_tensor_from_numpy_array(backend, dtype):
+  """
+  Creates a numpy array, initializes a Tensor from it, and checks that all
+  its members have been correctly initialized.
+  """
+  A, init = testing_utils.safe_zeros((2, 3, 1), backend, dtype)
+  if A is None:
+    return
+  assert A.backend.name == backend
+  np.testing.assert_allclose(A.array, init)
+  assert A.shape == init.shape
+  assert A.size == init.size
+  assert A.ndim == init.ndim
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_init_tensor_from_backend_array(backend, dtype):
+  """
+  Creates an instance of the backend's array class, initializes a Tensor from
+  it, and checks that all its members have been correctly initialized.
+  """
+  shape = (2, 3, 1)
+  if backend == "pytorch":
+    if dtype not in testing_utils.torch_supported_dtypes:
+      with pytest.raises(TypeError):
+        dtype = testing_utils.np_dtype_to_backend(backend, dtype)
+      return
+
+    dtype = testing_utils.np_dtype_to_backend(backend, dtype)
+    init = torch.zeros(shape, dtype=dtype)
+  elif backend == "numpy":
+    dtype = testing_utils.np_dtype_to_backend(backend, dtype)
+    init = np.zeros(shape, dtype=dtype)
+  elif backend == "jax":
+    dtype = testing_utils.np_dtype_to_backend(backend, dtype)
+    init = jnp.zeros(shape, dtype=dtype)
+  elif backend == "tensorflow":
+    dtype = testing_utils.np_dtype_to_backend(backend, dtype)
+    init = tf.zeros(shape, dtype=dtype)
+  else:
+    raise ValueError("Unexpected backend ", backend)
+  A = tensornetwork.Tensor(init, backend=backend)
+  assert A.backend.name == backend
+  np.testing.assert_allclose(A.array, init)
+  assert A.shape == init.shape
+  assert A.size == np.prod(init.shape)
+  assert A.ndim == init.ndim
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_tensor_dtype(backend, dtype):
+  """ Checks that Tensor.dtype works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_zeros(shape, backend, dtype)
+  if A is None:
+    return
+  if backend != "pytorch":
+    assert A.dtype == init.dtype
+  else:
+    assert A.dtype == torch.tensor(init).dtype
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_tensor_T(backend, dtype):
+  """ Checks that Tensor.T works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.T.array, init.T)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_not_bool)
+def test_tensor_H(backend, dtype):
+  """ Checks that Tensor.H works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.H.array, init.conj().T)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_not_bool)
+def test_tensor_conj(backend, dtype):
+  """ Checks that Tensor.conj() works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.conj().array, A.backend.conj(init))
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_not_bool)
+def test_tensor_conjugate(backend, dtype):
+  """ Checks that Tensor.conjugate() works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.conjugate().array, A.backend.conj(init))
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_tensor_copy(backend, dtype):
+  """ Checks that Tensor.copy() works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.copy().array, init.copy())
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_tensor_reshape(backend, dtype):
+  """ Checks that Tensor.copy() works.
+  """
+  shape = (2, 3, 1)
+  newshape = (6, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.reshape(newshape).array,
+                               init.reshape(newshape))
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_tensor_transpose(backend, dtype):
+  """ Checks that Tensor.transpose() works.
+  """
+  shape = (2, 3, 1)
+  permutation = (1, 2, 0)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    test = A.backend.convert_to_tensor(init)
+    test = A.backend.transpose(test, perm=permutation)
+    np.testing.assert_allclose(A.transpose(perm=permutation).array, test)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_tensor_squeeze(backend, dtype):
+  """ Checks that Tensor.squeeze() works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.squeeze().array, init.squeeze())
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_tensor_ravel(backend, dtype):
+  """ Checks that Tensor.ravel() works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.ravel().array, init.ravel())
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
+def test_tensor_flatten(backend, dtype):
+  """ Checks that Tensor.flatten() works.
+  """
+  shape = (2, 3, 1)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    np.testing.assert_allclose(A.flatten().array, init.flatten())
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_not_bool)
+def test_tensor_hconj(backend, dtype):
+  """ Checks that Tensor.hconj() works.
+  """
+  shape = (2, 3, 1)
+  permutation = (1, 2, 0)
+  A, init = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    test = A.backend.convert_to_tensor(init)
+    test = A.backend.transpose(A.backend.conj(test), perm=permutation)
+    np.testing.assert_allclose(A.hconj(perm=permutation).array, test)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_multiply(backend, dtype):
+  """ Checks that Tensor*Tensor works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B, initB = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    testB = B.backend.convert_to_tensor(initB)
+    result = A * B
+    result2 = A.backend.multiply(testA, testB)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_scalar_multiply(backend, dtype):
+  """ Checks that Tensor*scalar works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B = 2.
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    result = A * B
+    result2 = A.backend.multiply(testA, B)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_scalar_rmultiply(backend, dtype):
+  """ Checks that scalar*Tensor works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B = 2.
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    result = B * A
+    result2 = A.backend.multiply(B, testA)
+    np.testing.assert_allclose(result.array, result2)
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_divide(backend, dtype):
+  """ Checks that Tensor/Tensor works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B, _ = testing_utils.safe_zeros(shape, backend, dtype)
+  if A is not None:
+    B = B + 1
+    testA = A.backend.convert_to_tensor(initA)
+    result = A / B
+    result2 = A.backend.divide(testA, B.array)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_scalar_divide(backend, dtype):
+  """ Checks that Tensor/scalar works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B = 2.
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    result = A / B
+    result2 = A.backend.divide(testA, B)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_addition(backend, dtype):
+  """ Checks that Tensor+Tensor works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B, initB = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    testB = B.backend.convert_to_tensor(initB)
+    result = A + B
+    result2 = A.backend.addition(testA, testB)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_scalar_addition(backend, dtype):
+  """ Checks that Tensor+scalar works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B = 2.
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    result = A + B
+    result2 = A.backend.addition(testA, B)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_scalar_raddition(backend, dtype):
+  """ Checks that scalar+Tensor works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B = 2.
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    result = B + A
+    result2 = A.backend.addition(B, testA)
+    np.testing.assert_allclose(result.array, result2)
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_subtraction(backend, dtype):
+  """ Checks that Tensor-Tensor works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B, initB = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    testB = B.backend.convert_to_tensor(initB)
+    result = A - B
+    result2 = A.backend.subtraction(testA, testB)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_scalar_subtraction(backend, dtype):
+  """ Checks that Tensor-scalar works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B = 2.
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    result = A - B
+    result2 = A.backend.subtraction(testA, B)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_scalar_rsubtraction(backend, dtype):
+  """ Checks that scalar-Tensor works.
+  """
+  shape = (2, 3, 1)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B = 2.
+  if A is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    result = B - A
+    result2 = A.backend.subtraction(B, testA)
+    np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_matmul(backend, dtype):
+  """ Checks that Tensor@Tensor works.
+  """
+  shape = (3, 3)
+  A, initA = testing_utils.safe_randn(shape, backend, dtype)
+  B, initB = testing_utils.safe_randn(shape, backend, dtype)
+  if A is not None and B is not None:
+    testA = A.backend.convert_to_tensor(initA)
+    testB = B.backend.convert_to_tensor(initB)
+    result = A @ B
+    result2 = A.backend.matmul(testA, testB)
+    np.testing.assert_allclose(result.array, result2)

--- a/tensornetwork/tests/tensor_test.py
+++ b/tensornetwork/tests/tensor_test.py
@@ -45,6 +45,24 @@ def test_init_tensor_from_numpy_array(backend, dtype):
   assert A.ndim == init.ndim
 
 
+@pytest.mark.parametrize("dtype", testing_utils.torch_supported_dtypes)
+def test_init_tensor_default_backend(dtype):
+  """ Creates a numpy array, initializes a Tensor from it, and checks that all
+  its members have been correctly initialized.
+  """
+  backend = backend_contextmanager.get_default_backend()
+  backend_obj = backends.backend_factory.get_backend(backend)
+  shape = (3, 5, 2)
+  testA = backend_obj.zeros(shape, dtype=dtype)
+  init = np.zeros(shape, dtype=dtype)
+  A = tensornetwork.Tensor(init)
+  assert A.backend.name == backend
+  np.testing.assert_allclose(A.array, testA)
+  assert A.shape == testA.shape
+  assert A.size == testA.size
+  assert A.ndim == testA.ndim
+
+
 @pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
 def test_init_tensor_from_backend_array(backend, dtype):
   """

--- a/tensornetwork/tests/tensor_test.py
+++ b/tensornetwork/tests/tensor_test.py
@@ -32,8 +32,7 @@ BaseBackend = abstract_backend.AbstractBackend
 
 @pytest.mark.parametrize("dtype", testing_utils.np_all_dtypes)
 def test_init_tensor_from_numpy_array(backend, dtype):
-  """
-  Creates a numpy array, initializes a Tensor from it, and checks that all
+  """ Creates a numpy array, initializes a Tensor from it, and checks that all
   its members have been correctly initialized.
   """
   A, init = testing_utils.safe_zeros((2, 3, 1), backend, dtype)
@@ -381,3 +380,22 @@ def test_tensor_matmul(backend, dtype):
     result = A @ B
     result2 = A.backend.matmul(testA, testB)
     np.testing.assert_allclose(result.array, result2)
+
+
+@pytest.mark.parametrize("dtype", testing_utils.np_float_dtypes)
+def test_tensor_ops_raise(dtype):
+  """ Checks that tensor operators raise the right error.
+  """
+  shape = (2, 3, 1)
+  A, _ = testing_utils.safe_randn(shape, "numpy", dtype)
+  B, _ = testing_utils.safe_randn(shape, "jax", dtype)
+  with pytest.raises(ValueError):
+    _ = A * B
+  with pytest.raises(ValueError):
+    _ = A + B
+  with pytest.raises(ValueError):
+    _ = A - B
+  with pytest.raises(ValueError):
+    _ = A / B
+  with pytest.raises(ValueError):
+    _ = A @ B

--- a/tensornetwork/tests/testing_utils.py
+++ b/tensornetwork/tests/testing_utils.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 import torch
 import pytest
 import tensornetwork
+from tensornetwork import backends
 config.update("jax_enable_x64", True)
 
 np_real = [np.float32, np.float64]

--- a/tensornetwork/tests/testing_utils.py
+++ b/tensornetwork/tests/testing_utils.py
@@ -63,7 +63,7 @@ def np_dtype_to_backend(backend, dtype):
   Converts a given np dtype to the equivalent in the given backend. Skips
   the present test if the dtype is not supported in the backend.
   """
-  backend_obj = backend.backend_factory.get_backend(backend)
+  backend_obj = backends.backend_factory.get_backend(backend)
   if backend_obj.name == "numpy":
     return dtype
   A_np = np.ones([1], dtype=dtype)

--- a/tensornetwork/tests/testing_utils.py
+++ b/tensornetwork/tests/testing_utils.py
@@ -1,0 +1,108 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import config
+import tensorflow as tf
+import torch
+import pytest
+import tensornetwork
+from tensornetwork import backends, backend_contextmanager
+config.update("jax_enable_x64", True)
+
+np_real = [np.float32, np.float64]
+np_complex = [np.complex64, np.complex128]
+np_float_dtypes = np_real + np_complex
+np_int = [np.int8, np.int16, np.int32, np.int64]
+np_uint = [np.uint8, np.uint16, np.uint32, np.uint64]
+np_not_bool = np_float_dtypes + np_int + np_uint + [None,]
+np_not_half = [np.float32, np.float64] + np_complex
+np_all_dtypes = np_not_bool + [np.bool,]
+
+torch_supported_dtypes = np_real + np_int + [np.uint8, np.bool, None]
+#torch_supported_dtypes = [np.float32, np.float64]
+
+def safe_randn(shape, backend, dtype):
+  """
+  Creates a random tensor , catching errors that occur when the
+  dtype is not supported by the backend. Returns the Tensor and the backend
+  array, which are both None if the dtype and backend did not match.
+  """
+  np.random.seed(seed=10)
+  init = np.random.randn(*shape)
+  if dtype == np.bool:
+    init = np.round(init)
+  init = init.astype(dtype)
+
+  if dtype in np_complex:
+    init_i = np.random.randn(*shape)
+    init = init + 1.0j * init_i.astype(dtype)
+
+  if backend == "pytorch" and dtype not in torch_supported_dtypes:
+    pytest.skip("dtype unsupported by PyTorch")
+    A = None
+    init = None
+  else:
+    A = tensornetwork.Tensor(init, backend=backend)
+  return (A, init)
+
+
+def safe_zeros(shape, backend, dtype):
+  """
+  Creates a tensor of zeros, catching errors that occur when the
+  dtype is
+  not supported by the backend. Returns both the Tensor and the backend array,
+  which are both None if the dtype and backend did not match.
+  """
+  init = np.zeros(shape, dtype=dtype)
+  if backend == "pytorch" and dtype not in torch_supported_dtypes:
+    pytest.skip("dtype unsupported by PyTorch")
+    A = None
+    init = None
+  else:
+    A = tensornetwork.Tensor(init, backend=backend)
+  return (A, init)
+
+
+def np_dtype_to_backend(backend, dtype):
+  """
+  Converts a given np dtype to the equivalent in the given backend. Skips
+  the present test if the dtype is not supported in the backend.
+  """
+  if backend is None:
+    backend = backend_contextmanager.get_default_backend()
+  backend_obj = backends.backend_factory.get_backend(backend)
+  if backend_obj.name == "numpy":
+    return dtype
+  A_np = np.ones([1], dtype=dtype)
+
+  if backend_obj.name == "jax":
+    A = jnp.array(A_np)
+  elif backend_obj.name == "tensorflow":
+    A = tf.convert_to_tensor(A_np, dtype=dtype)
+  elif backend_obj.name == "pytorch":
+    if dtype not in torch_supported_dtypes:
+      pytest.skip("dtype unsupported by PyTorch")
+
+    A = torch.tensor(A_np)
+  else:
+    raise ValueError("Invalid backend ", backend)
+  return A.dtype
+
+
+def check_contraction_dtype(backend, dtype):
+  """
+  Skips the test if the backend cannot perform multiply-add with the given
+  dtype.
+  """
+  skip = False
+  if backend == "tensorflow":
+    if dtype in [np.uint8, tf.uint8, np.uint16, tf.uint16, np.int8, tf.int8,
+                 np.int16, tf.int16, np.uint32, tf.uint32, np.uint64,
+                 tf.uint64]:
+      skip = True
+
+  if backend == "pytorch":
+    if dtype in [np.float16, torch.float16]:
+      skip = True
+  if skip:
+    pytest.skip("backend does not support multiply-add with this dtype.")


### PR DESCRIPTION
Adds tensornetwork/tensor.py, which contains the vaunted array class of yore, along with tests of its methods. Also modifies the backend transpose functions to make perm an optional keyword argument, with all axes reversed by default. Adds tests of this default behaviour in all backends except Symmetric, because I couldn't figure out how to do it in Symmetric.