### PR TITLE
fixed missing edge in create_MPS

### DIFF
--- a/docs/basic_mps.rst
+++ b/docs/basic_mps.rst
@@ -123,6 +123,7 @@ We begin by creating directly the node structure of the MPS. First we define fun
     #connect edges to build mps
     connected_edges=[]
     conn=mps[0][1]^mps[1][0]
+    connected_edges.append(conn)
     for k in range(1,rank-1):
         conn=mps[k][2]^mps[k+1][0]
         connected_edges.append(conn)


### PR DESCRIPTION
The first edge created for the case where rank = 2 was not being appended to the connected_edges array