### PR TITLE
Add power method and test to numpy backend.

### DIFF
--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -759,3 +759,24 @@ class NumPyBackend(abstract_backend.AbstractBackend):
     m.write(s.encode('latin-1'))
     m.seek(0)
     return np.load(m)
+  
+  def power(self, a: Tensor, b: Union[Tensor, float]) -> Tensor:
+    """
+    Returns the exponentiation of tensor a raised to b.  
+      If b is a tensor, then the exponentiation is element-wise 
+        between the two tensors, with a as the base and b as the power.
+        Note that a and b must be broadcastable to the same shape if 
+        b is a tensor.
+      If b is a scalar, then the exponentiation is each value in a
+        raised to the power of b.
+    
+    Args:
+      a: The tensor containing the bases.
+      b: The tensor containing the powers; or a single scalar as the power.
+
+    Returns:
+      The tensor that is each element of a raised to the 
+        power of b.  Note that the shape of the returned tensor
+        is that produced by the broadcast of a and b.
+    """
+    return np.power(a, b)

--- a/tensornetwork/backends/numpy/numpy_backend_test.py
+++ b/tensornetwork/backends/numpy/numpy_backend_test.py
@@ -949,3 +949,17 @@ def test_serialize(dtype):
   s = backend.serialize_tensor(tensor)
   assert isinstance(s, str)
   assert (tensor == backend.deserialize_tensor(s)).all()
+
+@pytest.mark.parametrize('dtype', np_dtypes)
+def test_power(dtype):
+  shape = (4, 3, 2)
+  backend = numpy_backend.NumPyBackend()
+  base_tensor = np.abs(backend.randn(shape, dtype=dtype, seed=10))
+  power_tensor = backend.randn(shape, dtype=dtype, seed=10)
+  actual = backend.power(base_tensor, power_tensor)
+  expected = np.power(base_tensor, power_tensor)
+  np.testing.assert_allclose(expected, actual)
+  power = np.random.rand(1)[0]
+  actual = backend.power(base_tensor, power)
+  expected = np.power(base_tensor, power)
+  np.testing.assert_allclose(expected, actual)


### PR DESCRIPTION
I'm a little unsure about the test method for power.

Due to how np.power works, if you have a negative base and raise that to a non-integer power you receive np.nan.  However, since the tests use backend.randn, it's very likely to get a negative value as a base and then try to raise that to a non-integer power, resulting in a runtime warning.

The current "solution" I have is to take the absolute value of the base tensor, ensuring the (-x)**(not-an-integer) situation never occurs.  Is there a better way to deal with the np.power quirk or does this suffice?  

Appreciate the feedback.