### PR TITLE
Pinv numpy backend

### DIFF
--- a/tensornetwork/backends/numpy/numpy_backend.py
+++ b/tensornetwork/backends/numpy/numpy_backend.py
@@ -795,3 +795,18 @@ class NumPyBackend(abstract_backend.AbstractBackend):
       float: Machine epsilon.
     """
     return np.finfo(dtype).eps
+
+  def pinv(self, tensor: Tensor, rcond: float = 1E-15, hermitian: bool = False) -> Tensor:
+    """
+    Compute the (Moore-Penrose) pseudo-inverse of a tensor.
+    Returns the pseudo-inverse of tensor.
+    
+    Args:
+     tensor: A tensor.
+     rcond: Cutoff for small singular values.
+     hermitian(optional): If True, matrix provided is assumed to be Hermitian (symmetric if real-valued). Defaults to False.
+
+    Returns:
+     tensor: The pseudo inverse of tensor.
+         """
+    return np.linalg.pinv(tensor)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -444,5 +444,4 @@ class TensorFlowBackend(abstract_backend.AbstractBackend):
     Returns:
      tensor: The pseudo inverse of tensor.
          """
-    raise NotImplementedError(
-        "Backend '{}' has not implemented pinv".format(self.name))
+    return np.linalg.pinv(tensor)

--- a/tensornetwork/backends/tensorflow/tensorflow_backend.py
+++ b/tensornetwork/backends/tensorflow/tensorflow_backend.py
@@ -430,3 +430,19 @@ class TensorFlowBackend(abstract_backend.AbstractBackend):
       float: Machine epsilon.
     """
     return tf.experimental.numpy.finfo(dtype).eps
+
+  def pinv(self, tensor: Tensor, rcond: float = 1E-15, hermitian: bool = False) -> Tensor:
+    """
+    Compute the (Moore-Penrose) pseudo-inverse of a tensor.
+    Returns the pseudo-inverse of tensor.
+    
+    Args:
+     tensor: A tensor.
+     rcond: Cutoff for small singular values.
+     hermitian(optional): If True, matrix provided is assumed to be Hermitian (symmetric if real-valued). Defaults to False.
+
+    Returns:
+     tensor: The pseudo inverse of tensor.
+         """
+    raise NotImplementedError(
+        "Backend '{}' has not implemented pinv".format(self.name))


### PR DESCRIPTION
This is done with respect to issue: #844
`pinv` function is added to `tensornetwork/backends/tensorflow/numpy_backend.py`
The `pinv` function has been referred from https://numpy.org/doc/stable/reference/generated/numpy.linalg.pinv.html
Please do have a look and let me know if should make any other change.
Thank you.