### PR TITLE
Export typing information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",
+    package_data={"tensornetwork": ["py.typed"]},
     packages=find_packages(),
 )


### PR DESCRIPTION
This commit adds the flag that the package contains typing
information. Therefore other packages can use the typing data to check their
code by mypy.

Ref.: https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages

Signed-off-by: Jan Luca Naumann <j.naumann@fu-berlin.de>