### PR TITLE
Fix JAX convert_to_tensor in anticipation of upcoming change

### DIFF
--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -121,8 +121,8 @@ class JaxBackend(abstract_backend.AbstractBackend):
   def convert_to_tensor(self, tensor: Tensor) -> Tensor:
     if (not isinstance(tensor, (np.ndarray, jnp.ndarray))
         and not jnp.isscalar(tensor)):
-      raise TypeError("Expected a `jnp.array`, `np.array` or scalar. Got {}".format(
-          type(tensor)))
+      raise TypeError(("Expected a `jnp.array`, `np.array` or scalar. "
+        f"Got {type(tensor)}"))
     result = jnp.asarray(tensor)
     return result
 

--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -119,8 +119,9 @@ class JaxBackend(abstract_backend.AbstractBackend):
     return jnp.sqrt(tensor)
 
   def convert_to_tensor(self, tensor: Tensor) -> Tensor:
-    if (not isinstance(tensor, jnp.ndarray) and not jnp.isscalar(tensor)):
-      raise TypeError("Expected a `jnp.array` or scalar. Got {}".format(
+    if (not isinstance(tensor, (np.ndarray, jnp.ndarray))
+        and not jnp.isscalar(tensor)):
+      raise TypeError("Expected a `jnp.array`, `np.array` or scalar. Got {}".format(
           type(tensor)))
     result = jnp.asarray(tensor)
     return result

--- a/tensornetwork/backends/jax/jax_backend.py
+++ b/tensornetwork/backends/jax/jax_backend.py
@@ -122,7 +122,7 @@ class JaxBackend(abstract_backend.AbstractBackend):
     if (not isinstance(tensor, (np.ndarray, jnp.ndarray))
         and not jnp.isscalar(tensor)):
       raise TypeError(("Expected a `jnp.array`, `np.array` or scalar. "
-        f"Got {type(tensor)}"))
+                       f"Got {type(tensor)}"))
     result = jnp.asarray(tensor)
     return result
 


### PR DESCRIPTION
[JAX] Replace uses of `isinstance(x, jax.numpy.ndarray)` with
`isinstance(x, (numpy.ndarray, jax.numpy.ndarray))` where
they were leading to test failures.

An upcoming change to JAX will make `isinstance(x, jax.numpy.ndarray)`
return true if and only if `x` is an instance of a JAX array type.

Previously `isinstance(x, jax.numpy.ndarray)` also returned true
for classic NumPy's `numpy.ndarray` objects as well. After the
upcoming change, it will return false for `numpy.ndarray` objects.
This change updates users of JAX who were depending on the
current behavior of the `isinstance` check to instead explicitly
check for `numpy.ndarray` instances as well.

These changes should have no effect on using `jax.numpy.ndarray` as
a type annotation. That does little and never has, although it is
possible that may change in the future. This change is strictly
about what `jax.numpy.ndarray` means to runtime `isinstance` checks.