### PR TITLE
Added init file.

### DIFF
--- a/tensornetwork/quantum/__init__.py
+++ b/tensornetwork/quantum/__init__.py
@@ -1,0 +1,1 @@
+from .quantum import *

--- a/tensornetwork/quantum/quantum.py
+++ b/tensornetwork/quantum/quantum.py
@@ -30,6 +30,8 @@ from tensornetwork.network_operations import get_subgraph_dangling, remove_node
 from tensornetwork.contractors import greedy
 Tensor = Any
 
+__all__ = ['quantum_constructor', 'identity', 'check_spaces', 'QuOperator',
+           'QuVector', 'QuAdjointVector', 'QuScalar', 'eliminate_identities']
 
 def quantum_constructor(
     out_edges: Sequence[Edge],

--- a/tensornetwork/quantum/quantum_test.py
+++ b/tensornetwork/quantum/quantum_test.py
@@ -15,7 +15,7 @@
 import pytest
 import numpy as np
 import tensornetwork as tn
-import quantum as qu
+import tensornetwork.quantum as qu
 
 
 def test_constructor(backend):


### PR DESCRIPTION
I added the init file to the quantum module. To import the module it suffices to do `tensornetwork.quantum` instead of `tensornetwork.quantum.quantum`. Also, the only imported functions are those included in `__all__`  so that autocompletion works better.