### PR TITLE
Add fallback to gesvd if gedd LAPACK fails in numpy backend

### DIFF
--- a/tensornetwork/backends/numpy/decompositions.py
+++ b/tensornetwork/backends/numpy/decompositions.py
@@ -14,7 +14,11 @@
 """Tensor Decomposition Numpy Implementation."""
 
 from typing import Optional, Any, Tuple
+import warnings
+
 import numpy
+import scipy
+
 Tensor = Any
 
 
@@ -33,7 +37,14 @@ def svd(
   right_dims = tensor.shape[pivot_axis:]
 
   tensor = np.reshape(tensor, [numpy.prod(left_dims), numpy.prod(right_dims)])
-  u, s, vh = np.linalg.svd(tensor, full_matrices=False)
+  try:
+    u, s, vh = np.linalg.svd(tensor, full_matrices=False)
+  except np.linalg.LinAlgError:
+    warnings.warn("NumPy SVD with the fast 'gesdd' LAPACK routine failed. " \
+      + "Matrix might be badly conditioned. Employing the SciPy SVD " \
+      + "with more stable 'gesvd' LAPACK routine instead.")
+    u, s, vh = scipy.linalg.svd(
+        tensor, full_matrices=False, lapack_driver='gesvd')
 
   if max_singular_values is None:
     max_singular_values = np.size(s)


### PR DESCRIPTION
Solves: #896

Hi TN people! 
Thank you very much for your work so far!

Much like in #896 users of our project [OQuPy](https://github.com/tempoCollaboration/OQuPy) experience sometimes non-reproducible "SVD did not converge" errors. Very unpleasantly they occur more often with large tensors that are often the result of hours of computation time. I believe most (if not all) of these errors could be avoided by falling back to the _gesvd LAPACK routine in scipy.

Numpy uses the _gesdd LAPACK routine for performing SVDs. In a nutshell: _gesdd routine is for large matrices much faster then the _gesvd routine, but _gesvd is more stabil for badly conditioned matrices.

If one searches for "scipy gesdd SVD did not converge" one finds a lot of issues on github and stackoverflow and 90% of the conversation can be summarised as "I cannot reproduce your/my issue."

In [this Issue](https://github.com/scipy/scipy/issues/7878), @pv (Pauli Virtranen) is pointing out: 
> Floating-point reproducibility is generally not guaranteed (see e.g. intel compiler manuals) on any platform, even for code in the same program can give different results due to e.g. data alignment, unless you take special care with library and compiler options, as it depends on things such as compiler optimizations. This is not generally considered a bug, and correct code should not assume it. It is a speed/precision tradeoff, and official binaries provided by scipy project do not ensure 100% fp reproducibility.

However, when browsing through the dozens of issues, it seems that they are often resolve when using the _gesvd LAPACK routine (through scipy). Because _gesdd is mostly much faster I think it is reasonable to keep this as the default, but fall back to the _gesvd routine if the _gesdd fails. This is also done in the TeNPy package [here](https://tenpy.readthedocs.io/en/v0.5.0/_modules/tenpy/linalg/svd_robust.html).

Following the Zen of Python: "Errors should never pass silently.", I've added a warning to the fall back to gesdd.
Unfortunately, I don't know how to test it, because I don't know how to construct a matrix that will fail reliably with gesdd.
