### PR TITLE
Fix `base` contraction

### DIFF
--- a/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
+++ b/tensornetwork/contractors/opt_einsum_paths/path_contractors.py
@@ -84,10 +84,16 @@ def base(nodes: Iterable[AbstractNode],
 
   # Then apply `opt_einsum`'s algorithm
   path, nodes = utils.get_path(nodes_set, algorithm)
-  for a, b in path:
-    new_node = contract_between(nodes[a], nodes[b], allow_outer_product=True)
+  for p in path:
+    if len(p) == 2:
+      a, b = p
+      new_node = contract_between(nodes[a], nodes[b], allow_outer_product=True)
+    elif len(p) == 1:
+      new_node = nodes[p[0]]
+    else:
+      raise NotImplementedError('Hypergraph contraction not supported.')
     nodes.append(new_node)
-    nodes = utils.multi_remove(nodes, [a, b])
+    nodes = utils.multi_remove(nodes, p)
 
   # if the final node has more than one edge,
   # output_edge_order has to be specified


### PR DESCRIPTION
Deals with scalar tensors in the network, where `opt_einsum` may include a 1-element tuples in the `opt_path`.

Current behaviour:

This errs
```python
import numpy as np
import tensornetwork as tn

a = tn.Node(np.array(2))
b = tn.Node(np.array(3))

tn.contractors.auto([a, b])
```

This errs

```python
import numpy as np
import tensornetwork as tn

a = tn.Node(np.array(2))
b = tn.Node(np.array([1, 2]))
c = tn.Node(np.array([3, 4]))

tn.connect(b[0], c[0])
tn.contractors.auto([a, b, c])
```

But this works.
```python
import numpy as np
import tensornetwork as tn

a = tn.Node(np.array([1, 2]))
b = tn.Node(np.array([3, 4]))
c = tn.Node(np.array([1, 2]))
d = tn.Node(np.array([3, 4]))

tn.connect(a[0], b[0])
tn.connect(c[0], d[0])
tn.contractors.auto([a, b, c, d])
```